### PR TITLE
Correct MaxPasswordLength to MaxPasswordage

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -23,7 +23,7 @@ Description: Checks that the IAM password policy enforces a maximum password age
 	node/iam_password_maximum_age-periodic.js
 
 Trigger Type: ```Periodic```
-Required Parameter: ```MaxPasswordLength```
+Required Parameter: ```MaxPasswordAge```
 Example Value: ```90```
 
 ### 4. Ensure IAM password policy requires an uppercase character.

--- a/node/iam_password_maximum_age-periodic.js
+++ b/node/iam_password_maximum_age-periodic.js
@@ -5,7 +5,7 @@
 // Description: Checks that the IAM password policy enforces a maximum password age
 //
 // Trigger Type: Periodic
-// Required Parameter: MaxPasswordLength
+// Required Parameter: MaxPasswordAge
 // Example Value: 90
 
 var aws  = require('aws-sdk');


### PR DESCRIPTION
For `node/iam_password_maximum_age-periodic.js`, the parameter key seems to be incorrect. This should resolve the documentation inconsistencies. 

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)