### PR TITLE
Add security-group by tag python rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -233,3 +233,13 @@ Description: Checks that all users have enabled multiple factor authentication.
 
 Trigger Type: ```Change Triggered```
 Scope of Changes: ```IAM:User```
+
+### 27. Ensure all EC2 Instances that have a certain tag format also have a specific security group
+Description: Checks that all EC2 instances that have match a tag format (via regex) also have a specific security group. For example, a tag regex of ```^prod(us|eu|br)[lw]box[0-9]{3}$``` will match ```produslbox001```.
+
+	python/ec2_require_security_group_by_tag.py
+
+Trigger Type: ```Change Triggered```
+Scope of Changes: ```EC2:Instance```
+Required Parameters: ```name```, ```secGroup```
+Example Value: ```^prod(us|eu|br)[lw]box[0-9]{3}$```, ```MyTestGroup```

--- a/RULES.md
+++ b/RULES.md
@@ -241,5 +241,5 @@ Description: Checks that all EC2 instances that have match a tag format (via reg
 
 Trigger Type: ```Change Triggered```
 Scope of Changes: ```EC2:Instance```
-Required Parameters: ```name```, ```secGroup```
+Required Parameters: ```namePattern```, ```securityGroupName```
 Example Value: ```^prod(us|eu|br)[lw]box[0-9]{3}$```, ```MyTestGroup```

--- a/python/ec2_require_security_group_by_tag.py
+++ b/python/ec2_require_security_group_by_tag.py
@@ -1,0 +1,71 @@
+#
+# This file made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+#
+# Ensure all EC2 Instances that have a certain tag format also have a specific security group
+# Description: Checks that all EC2 instances that have a certain tag format also have a specific security group
+#
+# Trigger Type: Change Triggered
+# Scope of Changes: EC2:Instance
+# Required Parameters: name
+# Example Value: ^prod(us|eu|br)[lw]box[0-9]{3}$ (which will match 'produslbox001')
+# Required Parameters: secGroup
+# Example Value: MySecGroup
+# 
+
+import boto3
+import json
+import re
+
+def is_applicable(config_item, event):
+    status = config_item['configurationItemStatus']
+    event_left_scope = event['eventLeftScope']
+    test = ((status in ['OK', 'ResourceDiscovered']) and
+            event_left_scope == False)
+    return test
+
+def evaluate_compliance(config_item, rule_parameters):
+    # Initialize evaluation to 'not applicable', i.e. rule doesn't apply
+    evaluation = 'NOT_APPLICABLE'
+    if (config_item['resourceType'] == 'AWS::EC2::Instance'):
+        configuration = config_item['configuration']
+        tags = configuration['tags']
+        foundTag = False
+        # If the config item is for an EC2 instance, then iterate through the tags for that instance
+        for tag in tags:
+            # Check if this is the name tag, and that it matches the provided regex value
+            reg = re.compile(rule_parameters['name'])
+            if (tag['key'] == 'Name') and (reg.match(tag['value']) != None):
+                # if so, initialize to 'non-compliant'
+                evaluation = 'NON_COMPLIANT'
+                secGroups = configuration['securityGroups']
+                # iterate through the security groups and see if the provided secGroup name is in the list. 
+                # if so, set compliance to 'compliant'
+                for secGroup in secGroups:
+                    if (secGroup['groupName'] == rule_parameters['secGroup']):
+                        evaluation = 'COMPLIANT'
+        
+    return evaluation
+
+def lambda_handler(event, context):
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = json.loads(event['ruleParameters'])
+
+    compliance_value = 'NOT_APPLICABLE'
+
+    if is_applicable(invoking_event['configurationItem'], event):
+        compliance_value = evaluate_compliance(
+                invoking_event['configurationItem'], rule_parameters)
+
+    config = boto3.client('config')
+    response = config.put_evaluations(
+       Evaluations=[
+           {
+               'ComplianceResourceType': invoking_event['configurationItem']['resourceType'],
+               'ComplianceResourceId': invoking_event['configurationItem']['resourceId'],
+               'ComplianceType': compliance_value,
+               'OrderingTimestamp': invoking_event['configurationItem']['configurationItemCaptureTime']
+           },
+       ],
+       ResultToken=event['resultToken'])
+
+

--- a/python/ec2_require_security_group_by_tag.py
+++ b/python/ec2_require_security_group_by_tag.py
@@ -19,31 +19,28 @@ import re
 def is_applicable(config_item, event):
     status = config_item['configurationItemStatus']
     event_left_scope = event['eventLeftScope']
-    test = ((status in ['OK', 'ResourceDiscovered']) and
-            event_left_scope == False)
-    return test
+    return ((status in ['OK', 'ResourceDiscovered']) and
+            (event_left_scope == False) and
+            (config_item['resourceType'] == 'AWS::EC2::Instance'))
 
 def evaluate_compliance(config_item, rule_parameters):
     # Initialize evaluation to 'not applicable', i.e. rule doesn't apply
     evaluation = 'NOT_APPLICABLE'
-    if (config_item['resourceType'] == 'AWS::EC2::Instance'):
-        configuration = config_item['configuration']
-        tags = configuration['tags']
-        foundTag = False
-        # If the config item is for an EC2 instance, then iterate through the tags for that instance
-        for tag in tags:
-            # Check if this is the name tag, and that it matches the provided regex value
-            reg = re.compile(rule_parameters['name'])
-            if (tag['key'] == 'Name') and (reg.match(tag['value']) != None):
-                # if so, initialize to 'non-compliant'
-                evaluation = 'NON_COMPLIANT'
-                secGroups = configuration['securityGroups']
-                # iterate through the security groups and see if the provided secGroup name is in the list. 
-                # if so, set compliance to 'compliant'
-                for secGroup in secGroups:
-                    if (secGroup['groupName'] == rule_parameters['secGroup']):
-                        evaluation = 'COMPLIANT'
-        
+    configuration = config_item['configuration']
+    tags = configuration['tags']
+    # If the config item is for an EC2 instance, then iterate through the tags for that instance
+    for tag in tags:
+        # Check if this is the 'Name' tag, and that it matches the provided regex value
+        reg = re.compile(rule_parameters['name'])
+        if (tag['key'] == 'Name') and (reg.match(tag['value']) != None):
+            # if so, initialize to 'non-compliant'
+            evaluation = 'NON_COMPLIANT'
+            secGroups = configuration['securityGroups']
+            # iterate through the security groups and see if the provided secGroup name is in the list. 
+            # if so, set compliance to 'compliant'
+            for secGroup in secGroups:
+                if (secGroup['groupName'] == rule_parameters['secGroup']):
+                    evaluation = 'COMPLIANT'
     return evaluation
 
 def lambda_handler(event, context):

--- a/python/ec2_require_security_group_by_tag.py
+++ b/python/ec2_require_security_group_by_tag.py
@@ -6,9 +6,9 @@
 #
 # Trigger Type: Change Triggered
 # Scope of Changes: EC2:Instance
-# Required Parameters: name
+# Required Parameters: namePattern
 # Example Value: ^prod(us|eu|br)[lw]box[0-9]{3}$ (which will match 'produslbox001')
-# Required Parameters: secGroup
+# Required Parameters: securityGroupName
 # Example Value: MySecGroup
 # 
 
@@ -28,10 +28,10 @@ def evaluate_compliance(config_item, rule_parameters):
     evaluation = 'NOT_APPLICABLE'
     configuration = config_item['configuration']
     tags = configuration['tags']
+    reg = re.compile(rule_parameters['namePattern'])
     # If the config item is for an EC2 instance, then iterate through the tags for that instance
     for tag in tags:
         # Check if this is the 'Name' tag, and that it matches the provided regex value
-        reg = re.compile(rule_parameters['name'])
         if (tag['key'] == 'Name') and (reg.match(tag['value']) != None):
             # if so, initialize to 'non-compliant'
             evaluation = 'NON_COMPLIANT'
@@ -39,7 +39,7 @@ def evaluate_compliance(config_item, rule_parameters):
             # iterate through the security groups and see if the provided secGroup name is in the list. 
             # if so, set compliance to 'compliant'
             for secGroup in secGroups:
-                if (secGroup['groupName'] == rule_parameters['secGroup']):
+                if (secGroup['groupName'] == rule_parameters['securityGroupName']):
                     evaluation = 'COMPLIANT'
     return evaluation
 


### PR DESCRIPTION
Add a new python rule that ensures all EC2 Instances that match a certain tag regex format also have a specific security group attached.