### PR TITLE
Fixed error on evaluating deleted resources and a typo in port list addition

### DIFF
--- a/python/ec2-exposed-instance.py
+++ b/python/ec2-exposed-instance.py
@@ -30,7 +30,7 @@ def find_exposed_ports(ip_permissions):
         if next((r for r in permission["IpRanges"]
                 if "0.0.0.0/0" in r["CidrIp"]), None):
                     exposed_ports.extend(range(permission["FromPort"],
-                                               permission["ToPort"])+1)
+                                               permission["ToPort"]+1))
     return exposed_ports
 
 
@@ -85,9 +85,16 @@ def evaluate_compliance(configuration_item, rule_parameters):
 
 
 def lambda_handler(event, context):
+
     invoking_event = json.loads(event["invokingEvent"])
     configuration_item = invoking_event["configurationItem"]
     rule_parameters = json.loads(event["ruleParameters"])
+
+    if configuration_item['configurationItemStatus'] == "ResourceDeleted":
+        return {
+            "compliance_type": "NON_COMPLIANT",
+            "annotation": "The configurationItem was deleted and therefore cannot be validated"
+        }
 
     result_token = "No token found."
     if "resultToken" in event:

--- a/python/ec2-exposed-instance.py
+++ b/python/ec2-exposed-instance.py
@@ -53,6 +53,12 @@ def evaluate_compliance(configuration_item, rule_parameters):
             configuration_item["resourceType"] + "."
         }
 
+    if configuration_item['configurationItemStatus'] == "ResourceDeleted":
+        return {
+            "compliance_type": "NOT_APPLICABLE",
+            "annotation": "The configurationItem was deleted and therefore cannot be validated"
+        }
+
     security_groups = configuration_item["configuration"].get("securityGroups")
 
     if security_groups is None:
@@ -89,12 +95,6 @@ def lambda_handler(event, context):
     invoking_event = json.loads(event["invokingEvent"])
     configuration_item = invoking_event["configurationItem"]
     rule_parameters = json.loads(event["ruleParameters"])
-
-    if configuration_item['configurationItemStatus'] == "ResourceDeleted":
-        return {
-            "compliance_type": "NON_COMPLIANT",
-            "annotation": "The configurationItem was deleted and therefore cannot be validated"
-        }
 
     result_token = "No token found."
     if "resultToken" in event:


### PR DESCRIPTION
Without the fixes above the function will throw the following error when evaluating a deleted resource
```
'NoneType' object has no attribute 'get': AttributeError Traceback (most recent call last): File "/var/task/ec2-exposed-instance.py", line 98, in lambda_handler evaluation = evaluate_compliance(configuration_item, rule_parameters) File "/var/task/ec2-exposed-instance.py", line 56, in evaluate_compliance security_groups = configuration_item["configuration"].get("securityGroups") AttributeError: 'NoneType' object has no attribute 'get'
```

And will throw the below error when evaluating any other resource due to a typo on line 33 when populating the port list.
```

can only concatenate list (not "int") to list: TypeError Traceback (most recent call last): File "/var/task/ec2-exposed-instance.py", line 99, in lambda_handler evaluation = evaluate_compliance(configuration_item, rule_parameters) File "/var/task/ec2-exposed-instance.py", line 72, in evaluate_compliance rule_parameters File "/var/task/ec2-exposed-instance.py", line 38, in find_violation exposed_ports = find_exposed_ports(ip_permissions) File "/var/task/ec2-exposed-instance.py", line 33, in find_exposed_ports permission["ToPort"])+1) TypeError: can only concatenate list (not "int") to list
```


I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)