### PR TITLE
Changed readSnapshot  to retrieve s3 bucket region prior to retrieval

### DIFF
--- a/node/cloudtrail_enabled_all_regions-periodic.js
+++ b/node/cloudtrail_enabled_all_regions-periodic.js
@@ -78,7 +78,7 @@ readSnapshot.returnConfig = function(s3key, s3bucket, s3region, callback){
         Bucket: s3bucket
     };
     var buffer = "";
-    s3client.getObject(params, callback)
+    s3client.getObject(params)
         .createReadStream()
         .pipe(zlib.createGunzip())
         .on('data', function(chunk) {

--- a/node/cloudtrail_enabled_all_regions-periodic.js
+++ b/node/cloudtrail_enabled_all_regions-periodic.js
@@ -71,7 +71,7 @@ var readSnapshot = function(s3key, s3bucket, callback) {
 // where Config is set up to deliver
 readSnapshot.returnConfig = function(s3key, s3bucket, s3region, callback){
 
-    var s3client = new aws.S3({region: 'us-east-1'});
+    var s3client = new aws.S3({region: s3region});
 
     var params = {
         Key: s3key,


### PR DESCRIPTION
Created constructor for readSnapshot to retrieve s3 bucket region to stop `PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint.` error when accessing config bucket from another region.  
Because the AWS Config bucket can be configured as a bucket in an external account it's possible that the home region for CloudTrail and the AWS Config bucket region may not match. Therefore I've added a constructor which finds the config bucket's S3 region in order to allow the getObject call to address the correct endpoint.  

I appreciate this PR is a little larger than my previous ones, but I welcome any feedback you have on alternative approaches!  

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)