### PR TITLE
Ignoring non IAM domain users

### DIFF
--- a/node/iam_mfa_require-triggered.js
+++ b/node/iam_mfa_require-triggered.js
@@ -43,6 +43,8 @@ exports.handler = function(event, context) {
     // Only call out Async if a User
     if (configurationItem.resourceType === 'AWS::IAM::User') {
 	   
+      if (/(.*).com$/.test(configurationItem.resourceName)) {
+
         iam.listMFADevices({ UserName: configurationItem.resourceName }, function(mfaerr, mfadata) {
 
             var ret = 'NON_COMPLIANT';
@@ -80,7 +82,7 @@ exports.handler = function(event, context) {
             });
 
 	    });
-	   
+	  }
     } else {
  
 	    // Put together the request that reports the evaluation status


### PR DESCRIPTION
This changes the Lambda function to only check users that have a "*.com" username for MFA devices.  