### PR TITLE
Added Support for IPv6 in VPC

### DIFF
--- a/python/ec2_security_group_ingress.py
+++ b/python/ec2_security_group_ingress.py
@@ -15,6 +15,8 @@
 # permissions.  Here is a policy that you can consider.  You should validate this for your own
 # environment
 #
+# 2017-01-13 - Added "Ipv6Ranges" key to REQUIRED_PERMISSIONS to accommodate IPv6 support in VPC
+#
 #{
 #   "Version": "2012-10-17",
 #   "Statement": [
@@ -61,7 +63,8 @@ REQUIRED_PERMISSIONS = [
     "ToPort" : 80,
     "UserIdGroupPairs" : [],
     "IpRanges" : [{"CidrIp" : "0.0.0.0/0"}],
-    "PrefixListIds" : []
+    "PrefixListIds" : [],
+    "Ipv6Ranges": []
 },
 {
     "IpProtocol" : "tcp",
@@ -69,7 +72,8 @@ REQUIRED_PERMISSIONS = [
     "ToPort" : 443,
     "UserIdGroupPairs" : [],
     "IpRanges" : [{"CidrIp" : "0.0.0.0/0"}],
-    "PrefixListIds" : []
+    "PrefixListIds" : [],
+    "Ipv6Ranges": []
 }]
 
 # normalize_parameters


### PR DESCRIPTION
The addition of IPv6 support to Amazon VPC resulted in a change to the underlying AWS IpPermissions data structure that is provided to events generated for the AWS Config service.    The REQUIRED_PERMISSIONS data structure that appeared in the code had not been adjusted to use the new format.   As a result, the lookups performed by the code were failing because the event IpPermissions contained an additional key ("Ipv6Ranges") which was not in REQUIRED_PERMISSIONS.  I added this missing key to REQUIRED_PERMISSIONS to correct the problem.