### PR TITLE
Added a fix for mfa rule to only evaluate console users

### DIFF
--- a/python/iam-mfa.py
+++ b/python/iam-mfa.py
@@ -10,7 +10,7 @@
 
 import json
 import boto3
-
+from botocore.exceptions import ClientError
 
 APPLICABLE_RESOURCES = ["AWS::IAM::User"]
 
@@ -24,8 +24,11 @@ def evaluate_compliance(configuration_item):
     iam = boto3.client("iam")
     try:
         iam.get_login_profile(UserName=user_name)
-    except:
-        return "COMPLIANT"
+    except ClientError as e:
+        if 'NoSuchEntity' in e.response['Error']['Code']:
+            return "COMPLIANT"
+        else:
+            raise e
     mfa = iam.list_mfa_devices(UserName=user_name)
 
     if len(mfa["MFADevices"]) > 0:

--- a/python/iam-mfa.py
+++ b/python/iam-mfa.py
@@ -20,8 +20,12 @@ def evaluate_compliance(configuration_item):
         return "NOT_APPLICABLE"
 
     user_name = configuration_item["configuration"]["userName"]
-
+    
     iam = boto3.client("iam")
+    try:
+        iam.get_login_profile(UserName=user_name)
+    except:
+        return "COMPLIANT"
     mfa = iam.list_mfa_devices(UserName=user_name)
 
     if len(mfa["MFADevices"]) > 0:


### PR DESCRIPTION
This rule was evaluating cli users which don't have a console password and hence cannot use MFA login mechanism. Added a check to fetch user profile before deciding on the MFA attached status. For cli user's get_login_profile will throw an exception which we can use to skip over these users.