### PR TITLE
Fix iam-unused-keys.py 

### DIFF
--- a/python/iam-unused-keys.py
+++ b/python/iam-unused-keys.py
@@ -9,59 +9,82 @@
 
 
 import json
-import boto3
+import logging
 
+import boto3
 
 APPLICABLE_RESOURCES = ["AWS::IAM::User"]
 
 
 def evaluate_compliance(configuration_item):
-    if configuration_item["resourceType"] not in APPLICABLE_RESOURCES:
-        return "NOT_APPLICABLE"
+    compliant = "COMPLIANT"
+    annotations = []
 
-    config = boto3.client("config")
-    resource_information = config.get_resource_config_history(
-        resourceType=configuration_item["resourceType"],
-        resourceId=configuration_item["resourceId"]
-    )
-    user_name = resource_information["configurationItems"][0]["resourceName"]
+    if configuration_item["resourceType"] not in APPLICABLE_RESOURCES:
+        compliant = "NOT_APPLICABLE"
+        annotations.append(
+            "Cannot use this rule for resource of type {}.".format(
+                configuration_item["resourceType"]))
+
+        return compliant, " ".join(annotations)
+
+    user_name = configuration_item["configuration"]["userName"]
 
     iam = boto3.client("iam")
     access_keys = iam.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
 
-    for access_key in access_keys:
-        access_key_id = access_key["AccessKeyId"]
-        access_key_status = access_key["Status"]
-        last_used = iam.get_access_key_last_used(AccessKeyId=access_key_id)
-        if access_key_status is "Active" and \
-                last_used.get("LastUsedDate") is None:
-            return "NON_COMPLIANT"
+    if access_keys:
+        for access_key in access_keys:
+            access_key_id = access_key["AccessKeyId"]
+            access_key_status = access_key["Status"]
 
-    return "COMPLIANT"
+            last_used_date = iam.get_access_key_last_used(
+                AccessKeyId=access_key_id
+            ).get("AccessKeyLastUsed").get("LastUsedDate")
+
+            if access_key_status == "Active" and last_used_date is None:
+                compliant = "NON_COMPLIANT"
+                annotations.append(
+                    "Access key with ID {} was never used.".format(
+                        access_key_id))
+            else:
+                annotations.append(
+                    "Access key with ID {} key was last used {}.".format(
+                        access_key_id, last_used_date))
+    else:
+        annotations.append("User do not have any active access key.")
+
+    return compliant, " ".join(annotations)
 
 
 def lambda_handler(event, context):
+    logging.debug("Input event: %s", event)
+
     invoking_event = json.loads(event["invokingEvent"])
     configuration_item = invoking_event["configurationItem"]
+
     result_token = "No token found."
     if "resultToken" in event:
         result_token = event["resultToken"]
 
-    config = boto3.client("config")
-    config.put_evaluations(
-        Evaluations=[
-            {
-                "ComplianceResourceType":
-                    configuration_item["resourceType"],
-                "ComplianceResourceId":
-                    configuration_item["resourceId"],
-                "ComplianceType":
-                    evaluate_compliance(configuration_item),
-                "Annotation":
-                    "The user hasn't logged in for a long time.",
-                "OrderingTimestamp":
-                    configuration_item["configurationItemCaptureTime"]
-            },
-        ],
-        ResultToken=result_token
-    )
+    try:
+        compliant, annotation = evaluate_compliance(configuration_item)
+
+        config = boto3.client("config")
+        config.put_evaluations(
+            Evaluations=[
+                {
+                    "ComplianceResourceType":
+                        configuration_item["resourceType"],
+                    "ComplianceResourceId":
+                        configuration_item["resourceId"],
+                    "ComplianceType": compliant,
+                    "Annotation": annotation,
+                    "OrderingTimestamp":
+                        configuration_item["configurationItemCaptureTime"]
+                },
+            ],
+            ResultToken=result_token,
+        )
+    except Exception as exception:
+        logging.error("Error computing compliance status: %s", exception)


### PR DESCRIPTION
\+ Add logging for debugging purpose
\+ Wrap compliance evaluation in a try except
\! Adapt to get_resource_config_history and configuration_item API changes, no need to do the get_resource_config_history call
\! Adapt to get_access_key_last_used API changes, LastUsedDate is now wrapped in AccessKeyLastUsed
\* Push something more relevant in the Annotation string

Merging this will fix https://github.com/awslabs/aws-config-rules/issues/50.

I confirm these files are made available under CC0 1.0 Universal 
(https://creativecommons.org/publicdomain/zero/1.0/legalcode)