### PR TITLE
Handled the case where an IAM User was deleted since the last evaluation.

### DIFF
--- a/python/iam-mfa.py
+++ b/python/iam-mfa.py
@@ -18,6 +18,9 @@ APPLICABLE_RESOURCES = ["AWS::IAM::User"]
 def evaluate_compliance(configuration_item):
     if configuration_item["resourceType"] not in APPLICABLE_RESOURCES:
         return "NOT_APPLICABLE"
+    
+    if not configuration_item["configuration"]:
+        return "NOT_APPLICABLE"
 
     user_name = configuration_item["configuration"]["userName"]
     


### PR DESCRIPTION
Handled the case where an IAM User was deleted since the last evaluation. The next time the config rule is run, the configuration_item["configuration"] will be 'None' causing a runtime error.