### PR TITLE
typo in test CLOUDTRAIL_ENABLED_V2

### DIFF
--- a/python/CLOUDTRAIL_ENABLED_V2/CLOUDTRAIL_ENABLED_V2_test.py
+++ b/python/CLOUDTRAIL_ENABLED_V2/CLOUDTRAIL_ENABLED_V2_test.py
@@ -43,7 +43,7 @@ class Boto3Mock():
 
 sys.modules['boto3'] = Boto3Mock()
 
-rule = __import__('CLOUTRAIL_ENABLED_V2')
+rule = __import__('CLOUDTRAIL_ENABLED_V2')
 
 class ComplianceTest(unittest.TestCase):
 


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
