### PR TITLE
Add IAM policy required config rule

### DIFF
--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
@@ -1,0 +1,405 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import json
+import datetime
+import boto3
+import botocore
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::IAM::Role'
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (useful for cross-account).
+ASSUME_ROLE_MODE = False
+
+#############
+# Main Code #
+#############
+
+
+def should_ignore_config_item(config_item, ignored_roles, ignored_users):
+    return (config_item['configurationItemStatus'] == 'ResourceDeleted')\
+            or (config_item['resourceType'] == 'AWS::IAM::Role' and config_item['resourceName'] in ignored_roles)\
+            or (config_item['resourceType'] == 'AWS::IAM::User' and config_item['resourceName'] in ignored_users)\
+            or (config_item['ARN'].rsplit("/")[1] == 'aws-service-role')
+
+
+def get_user_policies(username):
+    client = boto3.client('iam')
+    # Get the users managed policies
+    policies = [
+        policy['PolicyName'] for policy in client.list_attached_user_policies(UserName=username)['AttachedPolicies']
+    ]
+    # Get the policies from the users groups
+    groups = [
+        group['GroupName'] for group in client.list_groups_for_user(UserName=username)['Groups']
+    ]
+    for group in groups:
+        policies.extend([
+            policy['PolicyName'] for policy in client.list_attached_group_policies(GroupName=group)['AttachedPolicies']
+        ])
+
+    return policies
+
+
+def get_role_policies(role_name):
+    client = boto3.client('iam')
+    # Get the users managed policies
+    return [
+        policy['PolicyName'] for policy in client.list_attached_role_policies(RoleName=role_name)['AttachedPolicies']
+    ]
+
+
+def has_policy_attached(resource_name, resource_type, policy_name):
+    if resource_type == 'AWS::IAM::User':
+        return policy_name in get_user_policies(resource_name)
+    elif resource_type == 'AWS::IAM::Role':
+        return policy_name in get_role_policies(resource_name)
+    else:
+        raise ValueError('Unable to handle resource type {}'.format(resource_type))
+
+
+def evaluate_compliance(event, configuration_item, valid_rule_parameters):
+    """Form the evaluation(s) to be return to Config Rules
+
+    Return either:
+    None -- when no result needs to be displayed
+    a string -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    a dictionary -- the evaluation dictionary, usually built by build_evaluation_from_config_item()
+    a list of dictionary -- a list of evaluation dictionary , usually built by build_evaluation()
+
+    Keyword arguments:
+    event -- the event variable given in the lambda handler
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    valid_rule_parameters -- the output of the evaluate_parameters() representing validated parameters of the Config Rule
+
+    Advanced Notes:
+    1 -- if a resource is deleted and generate a configuration change with ResourceDeleted status, the Boilerplate code will put a NOT_APPLICABLE on this resource automatically.
+    2 -- if a None or a list of dictionary is returned, the old evaluation(s) which are not returned in the new evaluation list are returned as NOT_APPLICABLE by the Boilerplate code
+    3 -- if None or an empty string, list or dict is returned, the Boilerplate code will put a "shadow" evaluation to feedback that the evaluation took place properly
+    """
+    ignored_roles = valid_rule_parameters["ignored_roles"]
+    ignored_users = valid_rule_parameters["ignored_users"]
+    policy_name = valid_rule_parameters['policy_name']
+
+    if should_ignore_config_item(configuration_item, ignored_roles, ignored_users):
+        return 'NOT_APPLICABLE'
+    elif has_policy_attached(configuration_item['resourceName'], configuration_item['resourceType'], policy_name):
+        return 'COMPLIANT'
+    else:
+        return 'NON_COMPLIANT'
+
+
+def evaluate_parameters(rule_parameters):
+    """Evaluate the rule parameters dictionary validity. Raise a ValueError for invalid parameters.
+
+    Return:
+    anything suitable for the evaluate_compliance()
+
+    Keyword arguments:
+    rule_parameters -- the Key/Value dictionary of the Config Rules parameters
+    """
+    valid_rule_parameters = rule_parameters
+    return valid_rule_parameters
+
+####################
+# Helper Functions #
+####################
+
+
+# Build an error to be displayed in the logs when the parameter is invalid.
+def build_parameters_value_error_response(ex):
+    """Return an error dictionary when the evaluate_parameters() raises a ValueError.
+
+    Keyword arguments:
+    ex -- Exception text
+    """
+    return  build_error_response(internalErrorMessage="Parameter value is invalid",
+                                 internalErrorDetails="An ValueError was raised during the validation of the Parameter value",
+                                 customerErrorCode="InvalidParameterValueException",
+                                 customerErrorMessage=str(ex))
+
+
+# This gets the client after assuming the Config service role
+# either in the same AWS account or cross-account.
+def get_client(service, event):
+    """Return the service boto client. It should be used instead of directly calling the client.
+
+    Keyword arguments:
+    service -- the service name used for calling the boto.client()
+    event -- the event variable given in the lambda handler
+    """
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service)
+    credentials = get_assume_role_credentials(event["executionRoleArn"])
+    return boto3.client(service, aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken']
+                       )
+
+
+# This generate an evaluation for config
+def build_evaluation(resource_id, compliance_type, event, resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on scheduled rules.
+
+    Keyword arguments:
+    resource_id -- the unique id of the resource to report
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    event -- the event variable given in the lambda handler
+    resource_type -- the CloudFormation resource type (or AWS::::Account) to report on the rule (default DEFAULT_RESOURCE_TYPE)
+    annotation -- an annotation to be added to the evaluation (default None)
+    """
+    eval_cc = {}
+    if annotation:
+        eval_cc['Annotation'] = annotation
+    eval_cc['ComplianceResourceType'] = resource_type
+    eval_cc['ComplianceResourceId'] = resource_id
+    eval_cc['ComplianceType'] = compliance_type
+    eval_cc['OrderingTimestamp'] = str(json.loads(event['invokingEvent'])['notificationCreationTime'])
+    return eval_cc
+
+def build_evaluation_from_config_item(configuration_item, compliance_type, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on configuration change rules.
+
+    Keyword arguments:
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    annotation -- an annotation to be added to the evaluation (default None)
+    """
+    eval_ci = {}
+    if annotation:
+        eval_ci['Annotation'] = annotation
+    eval_ci['ComplianceResourceType'] = configuration_item['resourceType']
+    eval_ci['ComplianceResourceId'] = configuration_item['resourceId']
+    eval_ci['ComplianceType'] = compliance_type
+    eval_ci['OrderingTimestamp'] = configuration_item['configurationItemCaptureTime']
+    return eval_ci
+
+####################
+# Boilerplate Code #
+####################
+
+# Helper function used to validate input
+def check_defined(reference, reference_name):
+    if not reference:
+        raise Exception('Error: ', reference_name, 'is not defined')
+    return reference
+
+# Check whether the message is OversizedConfigurationItemChangeNotification or not
+def is_oversized_changed_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'OversizedConfigurationItemChangeNotification'
+
+# Check whether the message is a ScheduledNotification or not.
+def is_scheduled_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'ScheduledNotification'
+
+# Get configurationItem using getResourceConfigHistory API
+# in case of OversizedConfigurationItemChangeNotification
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1)
+    configurationItem = result['configurationItems'][0]
+    return convert_api_configuration(configurationItem)
+
+# Convert from the API model to the original invocation model
+def convert_api_configuration(configurationItem):
+    for k, v in configurationItem.items():
+        if isinstance(v, datetime.datetime):
+            configurationItem[k] = str(v)
+    configurationItem['awsAccountId'] = configurationItem['accountId']
+    configurationItem['ARN'] = configurationItem['arn']
+    configurationItem['configurationStateMd5Hash'] = configurationItem['configurationItemMD5Hash']
+    configurationItem['configurationItemVersion'] = configurationItem['version']
+    configurationItem['configuration'] = json.loads(configurationItem['configuration'])
+    if 'relationships' in configurationItem:
+        for i in range(len(configurationItem['relationships'])):
+            configurationItem['relationships'][i]['name'] = configurationItem['relationships'][i]['relationshipName']
+    return configurationItem
+
+# Based on the type of message get the configuration item
+# either from configurationItem in the invoking event
+# or using the getResourceConfigHistiry API in getConfiguration function.
+def get_configuration_item(invokingEvent):
+    check_defined(invokingEvent, 'invokingEvent')
+    if is_oversized_changed_notification(invokingEvent['messageType']):
+        configurationItemSummary = check_defined(invokingEvent['configurationItemSummary'], 'configurationItemSummary')
+        return get_configuration(configurationItemSummary['resourceType'], configurationItemSummary['resourceId'], configurationItemSummary['configurationItemCaptureTime'])
+    elif is_scheduled_notification(invokingEvent['messageType']):
+        return None
+    return check_defined(invokingEvent['configurationItem'], 'configurationItem')
+
+# Check whether the resource has been deleted. If it has, then the evaluation is unnecessary.
+def is_applicable(configurationItem, event):
+    try:
+        check_defined(configurationItem, 'configurationItem')
+        check_defined(event, 'event')
+    except:
+        return True
+    status = configurationItem['configurationItemStatus']
+    eventLeftScope = event['eventLeftScope']
+    if status == 'ResourceDeleted':
+        print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
+    return (status == 'OK' or status == 'ResourceDiscovered') and not eventLeftScope
+
+def get_assume_role_credentials(role_arn):
+    sts_client = boto3.client('sts')
+    try:
+        assume_role_response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName="configLambdaExecution")
+        return assume_role_response['Credentials']
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        print(str(ex))
+        if 'AccessDenied' in ex.response['Error']['Code']:
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response['Error']['Message'] = "InternalError"
+            ex.response['Error']['Code'] = "InternalError"
+        raise ex
+
+# This removes older evaluation (usually useful for periodic rule not reporting on AWS::::Account).
+def clean_up_old_evaluations(latest_evaluations, event):
+
+    cleaned_evaluations = []
+
+    old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+        ConfigRuleName=event['configRuleName'],
+        ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+        Limit=100)
+
+    old_eval_list = []
+
+    while True:
+        for old_result in old_eval['EvaluationResults']:
+            old_eval_list.append(old_result)
+        if 'NextToken' in old_eval:
+            next_token = old_eval['NextToken']
+            old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+                ConfigRuleName=event['configRuleName'],
+                ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+                Limit=100,
+                NextToken=next_token)
+        else:
+            break
+
+    for old_eval in old_eval_list:
+        old_resource_id = old_eval['EvaluationResultIdentifier']['EvaluationResultQualifier']['ResourceId']
+        newer_founded = False
+        for latest_eval in latest_evaluations:
+            if old_resource_id == latest_eval['ComplianceResourceId']:
+                newer_founded = True
+        if not newer_founded:
+            cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
+
+    return cleaned_evaluations + latest_evaluations
+
+# This decorates the lambda_handler in rule_code with the actual PutEvaluation call
+def lambda_handler(event, context):
+
+    global AWS_CONFIG_CLIENT
+
+    #print(event)
+    check_defined(event, 'event')
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = {}
+    if 'ruleParameters' in event:
+        rule_parameters = json.loads(event['ruleParameters'])
+
+    try:
+        valid_rule_parameters = evaluate_parameters(rule_parameters)
+    except ValueError as ex:
+        return build_parameters_value_error_response(ex)
+
+    try:
+        AWS_CONFIG_CLIENT = get_client('config', event)
+        if invoking_event['messageType'] in ['ConfigurationItemChangeNotification', 'ScheduledNotification', 'OversizedConfigurationItemChangeNotification']:
+            configuration_item = get_configuration_item(invoking_event)
+            if is_applicable(configuration_item, event):
+                compliance_result = evaluate_compliance(event, configuration_item, valid_rule_parameters)
+            else:
+                compliance_result = "NOT_APPLICABLE"
+        else:
+            return build_internal_error_response('Unexpected message type', str(invoking_event))
+    except botocore.exceptions.ClientError as ex:
+        if is_internal_error(ex):
+            return build_internal_error_response("Unexpected error while completing API request", str(ex))
+        return build_error_response("Customer error while making API request", str(ex), ex.response['Error']['Code'], ex.response['Error']['Message'])
+    except ValueError as ex:
+        return build_internal_error_response(str(ex), str(ex))
+
+    evaluations = []
+    latest_evaluations = []
+
+    if not compliance_result:
+        latest_evaluations.append(build_evaluation(event['accountId'], "NOT_APPLICABLE", event, resource_type='AWS::::Account'))
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, str):
+        if configuration_item:
+            evaluations.append(build_evaluation_from_config_item(configuration_item, compliance_result))
+        else:
+            evaluations.append(build_evaluation(event['accountId'], compliance_result, event, resource_type=DEFAULT_RESOURCE_TYPE))
+    elif isinstance(compliance_result, list):
+        for evaluation in compliance_result:
+            missing_fields = False
+            for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+                if field not in evaluation:
+                    print("Missing " + field + " from custom evaluation.")
+                    missing_fields = True
+
+            if not missing_fields:
+                latest_evaluations.append(evaluation)
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, dict):
+        missing_fields = False
+        for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+            if field not in compliance_result:
+                print("Missing " + field + " from custom evaluation.")
+                missing_fields = True
+        if not missing_fields:
+            evaluations.append(compliance_result)
+    else:
+        evaluations.append(build_evaluation_from_config_item(configuration_item, 'NOT_APPLICABLE'))
+
+    # Put together the request that reports the evaluation status
+    resultToken = event['resultToken']
+    testMode = False
+    if resultToken == 'TESTMODE':
+        # Used solely for RDK test to skip actual put_evaluation API call
+        testMode = True
+    # Invoke the Config API to report the result of the evaluation
+    AWS_CONFIG_CLIENT.put_evaluations(Evaluations=evaluations, ResultToken=resultToken, TestMode=testMode)
+    # Used solely for RDK test to be able to test Lambda function
+    return evaluations
+
+def is_internal_error(exception):
+    return ((not isinstance(exception, botocore.exceptions.ClientError)) or exception.response['Error']['Code'].startswith('5')
+            or 'InternalError' in exception.response['Error']['Code'] or 'ServiceError' in exception.response['Error']['Code'])
+
+def build_internal_error_response(internalErrorMessage, internalErrorDetails=None):
+    return build_error_response(internalErrorMessage, internalErrorDetails, 'InternalError', 'InternalError')
+
+def build_error_response(internalErrorMessage, internalErrorDetails=None, customerErrorCode=None, customerErrorMessage=None):
+    error_response = {
+        'internalErrorMessage': internalErrorMessage,
+        'internalErrorDetails': internalErrorDetails,
+        'customerErrorMessage': customerErrorMessage,
+        'customerErrorCode': customerErrorCode
+    }
+    print(error_response)
+    return error_response

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
@@ -24,9 +24,9 @@
    | ---------------------- | --------- | -------------------------------------------------------- |
    | Parameter Name         | Type      | Description                                              |
    | ---------------------- | --------- | -------------------------------------------------------- |
-   | policyArns             | Required  | ARNs of the policies which should be attached to all     |
-   |                        |           | users and roles.                                         |
-   |                        |           | Example: ["arn:aws:iam::012345678912:policy/MyPolicy"]   |
+   | policyArns             | Required  | Comma separated list of policy ARNs which should be      |
+   |                        |           | attached to users and roles.                             |
+   |                        |           | Example: "arn:aws:iam::012345678912:policy/MyPolicy"     |
    | ---------------------- | --------- | -------------------------------------------------------- |
    | exceptionList          | Optional  | Represents the IAM users and roles which are exempted    |
    |                        |           | from the IAM Config rule. The valid entities in this list|
@@ -216,9 +216,7 @@ def evaluate_parameters(rule_parameters):
     Keyword arguments:
     rule_parameters -- the Key/Value dictionary of the Config Rules parameters
     """
-    policy_arns = rule_parameters["policyArns"]
-    if not isinstance(policy_arns, list):
-        raise ValueError('Invalid policyArns. Must be a list')
+    policy_arns = rule_parameters.get("policyArns", "").split(",")
     if not all(is_valid_arn(arn) for arn in policy_arns):
         raise ValueError('Invalid policy ARNs specified in policyArns')
 

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
@@ -206,7 +206,7 @@ def extract_entities_from_exception_list(entity_type, exception_list):
     pattern = re.compile("{Type}:\s?\[([a-zA-Z0-9-_,]+)\]".format(Type=entity_type))
     matches = pattern.search(exception_list)
     if matches:
-        return matches.group(1).split(",")
+        return matches.group(1).replace(' ', '').split(",")
     else:
         return []
 

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
@@ -81,7 +81,7 @@
       Then: Return COMPLIANT
    Scenario: 7
      Given: An IAM user exists
-       And: The IAM user does not have all the polciies listed in policyArns attached
+       And: The IAM user does not have all the policies listed in policyArns attached
        And: The IAM user's groups combined do not have all the policy listed in policyArns attached
       When: Evaluation occurs
       Then: return NON_COMPLIANT

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED.py
@@ -87,13 +87,13 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
     2 -- if a None or a list of dictionary is returned, the old evaluation(s) which are not returned in the new evaluation list are returned as NOT_APPLICABLE by the Boilerplate code
     3 -- if None or an empty string, list or dict is returned, the Boilerplate code will put a "shadow" evaluation to feedback that the evaluation took place properly
     """
-    ignored_roles = valid_rule_parameters["ignored_roles"]
-    ignored_users = valid_rule_parameters["ignored_users"]
-    policy_name = valid_rule_parameters['policy_name']
+    ignored_roles = valid_rule_parameters["ignoredRoles"]
+    ignored_users = valid_rule_parameters["ignoredUsers"]
+    policy_name = valid_rule_parameters['policyName']
     client = get_client('iam', event)
 
     if should_ignore_config_item(configuration_item, ignored_roles, ignored_users):
-        return 'NOT_APPLICABLE'
+        return 'COMPLIANT'
     elif has_policy_attached(configuration_item['resourceName'], configuration_item['resourceType'], policy_name, client):
         return 'COMPLIANT'
     else:

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
@@ -146,7 +146,7 @@ rule = __import__('IAM_POLICY_REQUIRED')
 
 class TestPolicyRequired(unittest.TestCase):
 
-    rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": ""}'
+    rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": ""}'
     invoking_event_iam_role_sample = json.dumps(build_role_configuration_item(['arn:aws:iam::aws:policy/AdministratorAccess']))
     invoking_event_iam_user_sample = json.dumps(build_user_configuration_item([
         'arn:aws:iam::aws:policy/AdministratorAccess'], {'group1': [{'PolicyArn':'arn:aws:iam::aws:policy/AdministratorAccess'}]}))
@@ -159,7 +159,7 @@ class TestPolicyRequired(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_ignored_roles_as_compliant(self):
-        rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": "users:[test-user],roles:[test-role]"}'
+        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user],roles:[test-role]"}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(build_lambda_configurationchange_event(
             self.invoking_event_iam_role_sample, rule_parameters), {})
@@ -167,7 +167,7 @@ class TestPolicyRequired(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_ignored_users_as_compliant(self):
-        rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": "users:[test-user]"}'
+        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user]"}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(build_lambda_configurationchange_event(
             self.invoking_event_iam_user_sample, rule_parameters), {})
@@ -234,7 +234,7 @@ class TestPolicyRequired(unittest.TestCase):
     def test_it_handles_customer_managed_policy_arns(self):
         invoking_event = json.dumps(build_role_configuration_item(
             ['arn:aws:iam::012345678912:policy/my-policy']))
-        rule_parameters = '{"policyArns":["arn:aws:iam::012345678912:policy/my-policy"], "exceptionList": ""}'
+        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-policy", "exceptionList": ""}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(
             build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
@@ -245,7 +245,7 @@ class TestPolicyRequired(unittest.TestCase):
     def test_it_handles_customer_managed_policy_arns_with_paths(self):
         invoking_event = json.dumps(build_role_configuration_item(
             ['arn:aws:iam::012345678912:policy/my-path/my-policy']))
-        rule_parameters = '{"policyArns":["arn:aws:iam::012345678912:policy/my-path/my-policy"], "exceptionList": ""}'
+        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-path/my-policy", "exceptionList": ""}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(
             build_lambda_configurationchange_event(invoking_event, rule_parameters), {})

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
@@ -146,7 +146,7 @@ rule = __import__('IAM_POLICY_REQUIRED')
 
 class TestPolicyRequired(unittest.TestCase):
 
-    rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": ""}'
+    rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": ""}'
     invoking_event_iam_role_sample = json.dumps(build_role_configuration_item(['arn:aws:iam::aws:policy/AdministratorAccess']))
     invoking_event_iam_user_sample = json.dumps(build_user_configuration_item([
         'arn:aws:iam::aws:policy/AdministratorAccess'], {'group1': [{'PolicyArn':'arn:aws:iam::aws:policy/AdministratorAccess'}]}))
@@ -159,7 +159,7 @@ class TestPolicyRequired(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_ignored_roles_as_compliant(self):
-        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user],roles:[test-role]"}'
+        rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": "users:[test-user],roles:[test-role]"}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(build_lambda_configurationchange_event(
             self.invoking_event_iam_role_sample, rule_parameters), {})
@@ -167,7 +167,7 @@ class TestPolicyRequired(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_ignored_users_as_compliant(self):
-        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user]"}'
+        rule_parameters = '{"policyArns":["arn:aws:iam::aws:policy/AdministratorAccess"], "exceptionList": "users:[test-user]"}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(build_lambda_configurationchange_event(
             self.invoking_event_iam_user_sample, rule_parameters), {})
@@ -234,7 +234,7 @@ class TestPolicyRequired(unittest.TestCase):
     def test_it_handles_customer_managed_policy_arns(self):
         invoking_event = json.dumps(build_role_configuration_item(
             ['arn:aws:iam::012345678912:policy/my-policy']))
-        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-policy", "exceptionList": ""}'
+        rule_parameters = '{"policyArns":["arn:aws:iam::012345678912:policy/my-policy"], "exceptionList": ""}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(
             build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
@@ -245,7 +245,7 @@ class TestPolicyRequired(unittest.TestCase):
     def test_it_handles_customer_managed_policy_arns_with_paths(self):
         invoking_event = json.dumps(build_role_configuration_item(
             ['arn:aws:iam::012345678912:policy/my-path/my-policy']))
-        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-path/my-policy", "exceptionList": ""}'
+        rule_parameters = '{"policyArns":["arn:aws:iam::012345678912:policy/my-path/my-policy"], "exceptionList": ""}'
         rule.ASSUME_ROLE_MODE = False
         response = rule.lambda_handler(
             build_lambda_configurationchange_event(invoking_event, rule_parameters), {})

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
@@ -40,7 +40,7 @@ rule = __import__('IAM_POLICY_REQUIRED')
 
 class TestPolicyRequired(unittest.TestCase):
 
-    rule_parameters = '{"policy_name":"TestPolicy", "ignored_users": "test-user", "ignored_roles": "test-role"}'
+    rule_parameters = '{"policyName":"TestPolicy", "ignoredUsers": "test-user", "ignoredRoles": "test-role"}'
 
     invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:role/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
     invoking_event_iam_user_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::User","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:user/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
@@ -55,7 +55,7 @@ class TestPolicyRequired(unittest.TestCase):
                                                                                                "role/aws-service-role/"),
                                                    self.rule_parameters), {})
 
-        resp_expected = [build_expected_response('NOT_APPLICABLE',
+        resp_expected = [build_expected_response('COMPLIANT',
                                                  unittest.mock.ANY,
                                                  'AWS::IAM::Role')]
         assert_successful_evaluation(self, response, resp_expected)

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
@@ -1,0 +1,251 @@
+import sys
+import unittest
+try:
+    from unittest.mock import MagicMock, patch, ANY
+except ImportError:
+    import mock
+    from mock import MagicMock, patch, ANY
+import botocore
+from botocore.exceptions import ClientError
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::IAM::Roe'
+
+#############
+# Main Code #
+#############
+
+config_client_mock = MagicMock()
+sts_client_mock = MagicMock()
+iam_client_mock = MagicMock()
+
+class Boto3Mock():
+    def client(self, client_name, *args, **kwargs):
+        if client_name == 'config':
+            return config_client_mock
+        elif client_name == 'sts':
+            return sts_client_mock
+        elif client_name == 'iam':
+            return iam_client_mock
+        else:
+            raise Exception("Attempting to create an unknown client")
+
+sys.modules['boto3'] = Boto3Mock()
+
+rule = __import__('IAM_POLICY_REQUIRED')
+
+class TestPolicyRequired(unittest.TestCase):
+
+    rule_parameters = '{"policy_name":"TestPolicy", "ignored_users": "test-user", "ignored_roles": "test-role"}'
+
+    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:role/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+    invoking_event_iam_user_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::User","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:user/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+
+    def setUp(self):
+        iam_client_mock.reset_mock()
+
+    def test_it_ignores_service_roles(self):
+        rule.ASSUME_ROLE_MODE = False
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample.replace("role/",
+                                                                                               "role/aws-service-role/"),
+                                                   self.rule_parameters), {})
+
+        resp_expected = [build_expected_response('NOT_APPLICABLE',
+                                                 unittest.mock.ANY,
+                                                 'AWS::IAM::Role')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_roles_with_policy_as_compliant(self):
+        rule.ASSUME_ROLE_MODE = False
+        iam_client_mock.configure_mock(**{
+            "list_attached_role_policies.return_value": {
+                'AttachedPolicies': [
+                    {
+                        'PolicyName': 'TestPolicy'
+                    }
+                ]
+            }
+        })
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::Role')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_users_with_policy_as_compliant(self):
+        rule.ASSUME_ROLE_MODE = False
+        iam_client_mock.configure_mock(**{
+            "list_attached_user_policies.return_value": {
+                'AttachedPolicies': [
+                    {
+                        'PolicyName': 'TestPolicy'
+                    }
+                ]
+            }
+        })
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+
+        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_users_in_group_with_policy_as_compliant(self):
+        rule.ASSUME_ROLE_MODE = False
+        iam_client_mock.configure_mock(**{
+            "list_groups_for_user.return_value": {
+                "Groups": [{
+                    "GroupName": "TestGroup"
+                }]
+            },
+            "list_attached_group_policies.return_value": {
+                'AttachedPolicies': [
+                    {
+                        'PolicyName': 'TestPolicy'
+                    }
+                ]
+            }
+        })
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+
+        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_users_without_policy_as_non_compliant(self):
+        rule.ASSUME_ROLE_MODE = False
+        iam_client_mock.configure_mock(**{
+            "list_groups_for_user.return_value": {"Groups": []},
+            "list_attached_user_policies.return_value": {"AttachedPolicies": []},
+        })
+
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+
+        resp_expected = [build_expected_response('NON_COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_roles_without_policy_as_non_compliant(self):
+        rule.ASSUME_ROLE_MODE = False
+        iam_client_mock.configure_mock(**{
+            "list_attached_role_policies.return_value": {
+                'AttachedPolicies': []
+            }
+        })
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+
+        resp_expected = [build_expected_response('NON_COMPLIANT', 'some-resource-id', 'AWS::IAM::Role')]
+        assert_successful_evaluation(self, response, resp_expected)
+
+
+####################
+# Helper Functions #
+####################
+
+def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_lambda_scheduled_event(rule_parameters=None):
+    invoking_event = '{"messageType":"ScheduledNotification","notificationCreationTime":"2017-12-23T22:11:18.158Z"}'
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_expected_response(compliance_type, compliance_resource_id, compliance_resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    if not annotation:
+        return {
+            'ComplianceType': compliance_type,
+            'ComplianceResourceId': compliance_resource_id,
+            'ComplianceResourceType': compliance_resource_type
+            }
+    return {
+        'ComplianceType': compliance_type,
+        'ComplianceResourceId': compliance_resource_id,
+        'ComplianceResourceType': compliance_resource_type,
+        'Annotation': annotation
+        }
+
+def assert_successful_evaluation(testClass, response, resp_expected, evaluations_count=1):
+    if isinstance(response, dict):
+        testClass.assertEquals(resp_expected['ComplianceResourceType'], response['ComplianceResourceType'])
+        testClass.assertEquals(resp_expected['ComplianceResourceId'], response['ComplianceResourceId'])
+        testClass.assertEquals(resp_expected['ComplianceType'], response['ComplianceType'])
+        testClass.assertTrue(response['OrderingTimestamp'])
+        if 'Annotation' in resp_expected or 'Annotation' in response:
+            testClass.assertEquals(resp_expected['Annotation'], response['Annotation'])
+    elif isinstance(response, list):
+        testClass.assertEquals(evaluations_count, len(response))
+        for i, response_expected in enumerate(resp_expected):
+            testClass.assertEquals(response_expected['ComplianceResourceType'], response[i]['ComplianceResourceType'])
+            testClass.assertEquals(response_expected['ComplianceResourceId'], response[i]['ComplianceResourceId'])
+            testClass.assertEquals(response_expected['ComplianceType'], response[i]['ComplianceType'])
+            testClass.assertTrue(response[i]['OrderingTimestamp'])
+            if 'Annotation' in response_expected or 'Annotation' in response[i]:
+                testClass.assertEquals(response_expected['Annotation'], response[i]['Annotation'])
+
+def assert_customer_error_response(testClass, response, customerErrorCode=None, customerErrorMessage=None):
+    if customerErrorCode:
+        testClass.assertEqual(customerErrorCode, response['customerErrorCode'])
+    if customerErrorMessage:
+        testClass.assertEqual(customerErrorMessage, response['customerErrorMessage'])
+    testClass.assertTrue(response['customerErrorCode'])
+    testClass.assertTrue(response['customerErrorMessage'])
+    if "internalErrorMessage" in response:
+        testClass.assertTrue(response['internalErrorMessage'])
+    if "internalErrorDetails" in response:
+        testClass.assertTrue(response['internalErrorDetails'])
+
+def sts_mock():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string"}}
+    sts_client_mock.reset_mock(return_value=True)
+    sts_client_mock.assume_role = MagicMock(return_value=assume_role_response)
+
+##################
+# Common Testing #
+##################
+
+class TestStsErrors(unittest.TestCase):
+
+    def test_sts_unknown_error(self):
+        rule.ASSUME_ROLE_MODE = True
+        sts_client_mock.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'unknown-code', 'Message': 'unknown-message'}}, 'operation'))
+        response = rule.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'InternalError', 'InternalError')
+
+    def test_sts_access_denied(self):
+        rule.ASSUME_ROLE_MODE = True
+        sts_client_mock.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation'))
+        response = rule.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'AccessDenied', 'AWS Config does not have permission to assume the IAM role.')

--- a/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
+++ b/python/IAM_POLICY_REQUIRED/IAM_POLICY_REQUIRED_test.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import unittest
 try:
@@ -13,7 +14,7 @@ from botocore.exceptions import ClientError
 ##############
 
 # Define the default resource to report to Config Rules
-DEFAULT_RESOURCE_TYPE = 'AWS::IAM::Roe'
+DEFAULT_RESOURCE_TYPE = 'AWS::IAM::Role'
 
 #############
 # Main Code #
@@ -36,109 +37,220 @@ class Boto3Mock():
 
 sys.modules['boto3'] = Boto3Mock()
 
+
+def build_user_configuration_item(attached_policies_arns, user_groups, user_name="test-user"):
+    return {
+        "configurationItemDiff": None,
+        "configurationItem": {
+            "relatedEvents": [],
+            "relationships": [
+                {
+                    "resourceId": "ABCDEFGHI12JKL4MNO5PQ",
+                    "resourceName": arn.rsplit("/")[-1],
+                    "resourceType": "AWS::IAM::Policy",
+                    "name": "Is attached to CustomerManagedPolicy"
+                } for arn in attached_policies_arns
+            ],
+            "configuration": {
+                "groupList": list(user_groups.keys()),
+                "userName": user_name,
+                "userId": "ABCDEFGHI12JKL4MNO5PQ",
+                "arn": "arn:aws:iam::0123456789012:user{Name}".format(Name=user_name),
+                "createDate": "2018-08-30T13:25:10.000Z",
+                "assumeRolePolicyDocument": "{}",
+                "instanceProfileList": [],
+                "rolePolicyList": [],
+                "attachedManagedPolicies": [
+                    {
+                        "policyName": arn.rsplit("/")[-1],
+                        "policyArn": arn
+                    } for arn in attached_policies_arns
+                ],
+                "permissionsBoundary": None
+            },
+            "supplementaryConfiguration": {},
+            "tags": {},
+            "configurationItemVersion": "1.3",
+            "configurationItemCaptureTime": "2018-09-07T11:24:32.476Z",
+            "configurationStateId": 12345678901,
+            "awsAccountId": "0123456789012",
+            "configurationItemStatus": "OK",
+            "resourceType": "AWS::IAM::User",
+            "resourceId": "ABCDEFGHI12JKL4MNO5PQ",
+            "resourceName": user_name,
+            "ARN": "arn:aws:iam::0123456789012:user/{}".format(user_name),
+            "awsRegion": "global",
+            "availabilityZone": "Not Applicable",
+            "configurationStateMd5Hash": "",
+            "resourceCreationTime": "2018-08-30T13:25:10.000Z"
+        },
+        "notificationCreationTime": "2018-09-21T09:24:28.962Z",
+        "messageType": "ConfigurationItemChangeNotification",
+        "recordVersion": "1.3"
+    }
+
+
+def build_role_configuration_item(attached_policies_arns, role_name="test-role", path="/"):
+    return {
+        "configurationItemDiff": None,
+        "configurationItem": {
+            "relatedEvents": [],
+            "relationships": [
+                {
+                    "resourceId": "ABCDEFGHI12JKL4MNO5PQ",
+                    "resourceName": arn.rsplit("/")[-1],
+                    "resourceType": "AWS::IAM::Policy",
+                    "name": "Is attached to CustomerManagedPolicy"
+                } for arn in attached_policies_arns
+            ],
+            "configuration": {
+                "path": path,
+                "roleName": role_name,
+                "roleId": "ABCDEFGHI12JKL4MNO5PQ",
+                "arn": "arn:aws:iam::0123456789012:role{Path}{Name}".format(Path=path, Name=role_name),
+                "createDate": "2018-08-30T13:25:10.000Z",
+                "assumeRolePolicyDocument": "{}",
+                "instanceProfileList": [],
+                "rolePolicyList": [],
+                "attachedManagedPolicies": [
+                    {
+                        "policyName": arn.rsplit("/")[-1],
+                        "policyArn": arn
+                    } for arn in attached_policies_arns
+                ],
+                "permissionsBoundary": None
+            },
+            "supplementaryConfiguration": {},
+            "tags": {},
+            "configurationItemVersion": "1.3",
+            "configurationItemCaptureTime": "2018-09-07T11:24:32.476Z",
+            "configurationStateId": 12345678901,
+            "awsAccountId": "0123456789012",
+            "configurationItemStatus": "OK",
+            "resourceType": "AWS::IAM::Role",
+            "resourceId": "ABCDEFGHI12JKL4MNO5PQ",
+            "resourceName": role_name,
+            "ARN": "arn:aws:iam::0123456789012:role/{}".format(role_name),
+            "awsRegion": "global",
+            "availabilityZone": "Not Applicable",
+            "configurationStateMd5Hash": "",
+            "resourceCreationTime": "2018-08-30T13:25:10.000Z"
+        },
+        "notificationCreationTime": "2018-09-21T09:24:28.962Z",
+        "messageType": "ConfigurationItemChangeNotification",
+        "recordVersion": "1.3"
+    }
+
+
 rule = __import__('IAM_POLICY_REQUIRED')
 
 class TestPolicyRequired(unittest.TestCase):
 
-    rule_parameters = '{"policyName":"TestPolicy", "ignoredUsers": "test-user", "ignoredRoles": "test-role"}'
+    rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": ""}'
+    invoking_event_iam_role_sample = json.dumps(build_role_configuration_item(['arn:aws:iam::aws:policy/AdministratorAccess']))
+    invoking_event_iam_user_sample = json.dumps(build_user_configuration_item([
+        'arn:aws:iam::aws:policy/AdministratorAccess'], {'group1': [{'PolicyArn':'arn:aws:iam::aws:policy/AdministratorAccess'}]}))
 
-    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:role/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
-    invoking_event_iam_user_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::User","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"arn:aws:iam::123456789012:user/some-resource-name"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
-
-    def setUp(self):
-        iam_client_mock.reset_mock()
-
-    def test_it_ignores_service_roles(self):
+    def test_it_marks_service_roles_as_compliant(self):
         rule.ASSUME_ROLE_MODE = False
-        response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample.replace("role/",
-                                                                                               "role/aws-service-role/"),
-                                                   self.rule_parameters), {})
+        response = rule.lambda_handler(build_lambda_configurationchange_event(
+            self.invoking_event_iam_role_sample.replace("role/", "role/aws-service-role/"), self.rule_parameters), {})
+        resp_expected = [build_expected_response('COMPLIANT', ANY, 'AWS::IAM::Role', ANY)]
+        assert_successful_evaluation(self, response, resp_expected)
 
-        resp_expected = [build_expected_response('COMPLIANT',
-                                                 unittest.mock.ANY,
-                                                 'AWS::IAM::Role')]
+    def test_it_marks_ignored_roles_as_compliant(self):
+        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user],roles:[test-role]"}'
+        rule.ASSUME_ROLE_MODE = False
+        response = rule.lambda_handler(build_lambda_configurationchange_event(
+            self.invoking_event_iam_role_sample, rule_parameters), {})
+        resp_expected = [build_expected_response('COMPLIANT', ANY, 'AWS::IAM::Role', ANY)]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_marks_ignored_users_as_compliant(self):
+        rule_parameters = '{"policyArns":"arn:aws:iam::aws:policy/AdministratorAccess", "exceptionList": "users:[test-user]"}'
+        rule.ASSUME_ROLE_MODE = False
+        response = rule.lambda_handler(build_lambda_configurationchange_event(
+            self.invoking_event_iam_user_sample, rule_parameters), {})
+        resp_expected = [build_expected_response('COMPLIANT', ANY, 'AWS::IAM::User', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_roles_with_policy_as_compliant(self):
+        invoking_event = json.dumps(build_role_configuration_item(['arn:aws:iam::aws:policy/AdministratorAccess']))
         rule.ASSUME_ROLE_MODE = False
-        iam_client_mock.configure_mock(**{
-            "list_attached_role_policies.return_value": {
-                'AttachedPolicies': [
-                    {
-                        'PolicyName': 'TestPolicy'
-                    }
-                ]
-            }
-        })
         response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
-        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::Role')]
+            build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = [build_expected_response('COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::Role', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_users_with_policy_as_compliant(self):
+        invoking_event = json.dumps(build_user_configuration_item([
+            'arn:aws:iam::aws:policy/AdministratorAccess'], {}))
         rule.ASSUME_ROLE_MODE = False
-        iam_client_mock.configure_mock(**{
-            "list_attached_user_policies.return_value": {
-                'AttachedPolicies': [
-                    {
-                        'PolicyName': 'TestPolicy'
-                    }
-                ]
-            }
-        })
         response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+            build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
 
-        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        resp_expected = [build_expected_response('COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::User', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_users_in_group_with_policy_as_compliant(self):
+        invoking_event = json.dumps(build_user_configuration_item(
+            [], {'group1': ['arn:aws:iam::aws:policy/AdministratorAccess']}))
         rule.ASSUME_ROLE_MODE = False
         iam_client_mock.configure_mock(**{
-            "list_groups_for_user.return_value": {
-                "Groups": [{
-                    "GroupName": "TestGroup"
+            "get_paginator.return_value": iam_client_mock,
+            "paginate.return_value": iam_client_mock,
+            "result_key_iters.return_value": [
+                [{
+                    'PolicyName': 'AdministratorAccess',
+                    'PolicyArn': 'arn:aws:iam::aws:policy/AdministratorAccess',
                 }]
-            },
-            "list_attached_group_policies.return_value": {
-                'AttachedPolicies': [
-                    {
-                        'PolicyName': 'TestPolicy'
-                    }
-                ]
-            }
+            ]
         })
+        iam_client_mock.list_attached_group_policies.__name__ = 'list_attached_group_policies'
         response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+            build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
 
-        resp_expected = [build_expected_response('COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        resp_expected = [build_expected_response('COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::User', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_users_without_policy_as_non_compliant(self):
+        invoking_event = json.dumps(build_user_configuration_item([], {}))
         rule.ASSUME_ROLE_MODE = False
-        iam_client_mock.configure_mock(**{
-            "list_groups_for_user.return_value": {"Groups": []},
-            "list_attached_user_policies.return_value": {"AttachedPolicies": []},
-        })
-
         response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_user_sample, self.rule_parameters), {})
+            build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
 
-        resp_expected = [build_expected_response('NON_COMPLIANT', 'some-resource-id', 'AWS::IAM::User')]
+        resp_expected = [build_expected_response('NON_COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::User', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_it_marks_roles_without_policy_as_non_compliant(self):
+        invoking_event = json.dumps(build_role_configuration_item([]))
         rule.ASSUME_ROLE_MODE = False
-        iam_client_mock.configure_mock(**{
-            "list_attached_role_policies.return_value": {
-                'AttachedPolicies': []
-            }
-        })
         response = rule.lambda_handler(
-            build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+            build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
 
-        resp_expected = [build_expected_response('NON_COMPLIANT', 'some-resource-id', 'AWS::IAM::Role')]
+        resp_expected = [build_expected_response('NON_COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::Role', ANY)]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_handles_customer_managed_policy_arns(self):
+        invoking_event = json.dumps(build_role_configuration_item(
+            ['arn:aws:iam::012345678912:policy/my-policy']))
+        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-policy", "exceptionList": ""}'
+        rule.ASSUME_ROLE_MODE = False
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+
+        resp_expected = [build_expected_response('COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::Role', ANY)]
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_it_handles_customer_managed_policy_arns_with_paths(self):
+        invoking_event = json.dumps(build_role_configuration_item(
+            ['arn:aws:iam::012345678912:policy/my-path/my-policy']))
+        rule_parameters = '{"policyArns":"arn:aws:iam::012345678912:policy/my-path/my-policy", "exceptionList": ""}'
+        rule.ASSUME_ROLE_MODE = False
+        response = rule.lambda_handler(
+            build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+
+        resp_expected = [build_expected_response('COMPLIANT', 'ABCDEFGHI12JKL4MNO5PQ', 'AWS::IAM::Role', ANY)]
         assert_successful_evaluation(self, response, resp_expected)
 
 

--- a/python/IAM_POLICY_REQUIRED/parameters.json
+++ b/python/IAM_POLICY_REQUIRED/parameters.json
@@ -5,7 +5,7 @@
     "SourceRuntime": "python3.6", 
     "RuleName": "IAM_POLICY_REQUIRED",
     "SourceEvents": "AWS::IAM::Role,AWS::IAM::User", 
-    "OptionalParameters": "{\"ignoredUsers\": \"\", \"ignoredRoles\": \"\"}",
-    "InputParameters": "{\"policyName\": \"\"}"
+    "OptionalParameters": "{\"exceptionList\": \"\"}",
+    "InputParameters": "{\"policyArns\": \"\"}"
   }
 }

--- a/python/IAM_POLICY_REQUIRED/parameters.json
+++ b/python/IAM_POLICY_REQUIRED/parameters.json
@@ -6,6 +6,6 @@
     "RuleName": "IAM_POLICY_REQUIRED",
     "SourceEvents": "AWS::IAM::Role,AWS::IAM::User", 
     "OptionalParameters": "{\"exceptionList\": \"\"}",
-    "InputParameters": "{\"policyArns\": \"\"}"
+    "InputParameters": "{\"policyArns\": [\"\"]}"
   }
 }

--- a/python/IAM_POLICY_REQUIRED/parameters.json
+++ b/python/IAM_POLICY_REQUIRED/parameters.json
@@ -1,0 +1,11 @@
+{
+  "Version": "1.0", 
+  "Parameters": {
+    "CodeKey": "IAM_POLICY_REQUIRED.zip", 
+    "SourceRuntime": "python3.6", 
+    "RuleName": "IAM_POLICY_REQUIRED",
+    "SourceEvents": "AWS::IAM::Role,AWS::IAM::User", 
+    "OptionalParameters": "{}", 
+    "InputParameters": "{\"policy_name\": \"\", \"ignored_users\": \"\", \"ignored_roles\": \"\"}"
+  }
+}

--- a/python/IAM_POLICY_REQUIRED/parameters.json
+++ b/python/IAM_POLICY_REQUIRED/parameters.json
@@ -5,7 +5,7 @@
     "SourceRuntime": "python3.6", 
     "RuleName": "IAM_POLICY_REQUIRED",
     "SourceEvents": "AWS::IAM::Role,AWS::IAM::User", 
-    "OptionalParameters": "{}", 
-    "InputParameters": "{\"policy_name\": \"\", \"ignored_users\": \"\", \"ignored_roles\": \"\"}"
+    "OptionalParameters": "{\"ignoredUsers\": \"\", \"ignoredRoles\": \"\"}",
+    "InputParameters": "{\"policyName\": \"\"}"
   }
 }

--- a/python/IAM_POLICY_REQUIRED/parameters.json
+++ b/python/IAM_POLICY_REQUIRED/parameters.json
@@ -6,6 +6,6 @@
     "RuleName": "IAM_POLICY_REQUIRED",
     "SourceEvents": "AWS::IAM::Role,AWS::IAM::User", 
     "OptionalParameters": "{\"exceptionList\": \"\"}",
-    "InputParameters": "{\"policyArns\": [\"\"]}"
+    "InputParameters": "{\"policyArns\": \"\"}"
   }
 }


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
Adds a Config Rule that verifies all IAM Roles/Users have the given policy attached to them (either directly or through groups). Includes ability to exclude certain roles/users from the rule