### PR TITLE
Adding new rule API_GW_EXECUTION_LOGGING_ENABLED

### DIFF
--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -196,7 +196,7 @@ def get_configuration_item(invoking_event):
     if is_oversized_changed_notification(invoking_event['messageType']):
         configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
         return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
-    elif is_scheduled_notification(invoking_event['messageType']):
+    if is_scheduled_notification(invoking_event['messageType']):
         return None
     return check_defined(invoking_event['configurationItem'], 'configurationItem')
 
@@ -210,7 +210,7 @@ def is_applicable(configuration_item, event):
     event_left_scope = event['eventLeftScope']
     if status == 'ResourceDeleted':
         print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
-    return (status == 'OK' or status == 'ResourceDiscovered') and not event_left_scope
+    return status in ("OK", "ResourceDiscovered") and not event_left_scope
 
 def get_assume_role_credentials(role_arn):
     sts_client = boto3.client('sts')

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -30,7 +30,7 @@ Scenarios:
      Then: Return ERROR
   Scenario: 2
     Given: The rule parameter is valid
-       And: In the Stage configuration item, atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter.
+       And: In the Stage configuration item, at least one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter.
      Then: Return NON_COMPLIANT
   Scenario: 3
     Given: The rule parameter is valid
@@ -74,9 +74,9 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
 
     #Resource Type AWS::ApiGateway::Stage
     if configuration_item['resourceType'] == 'AWS::ApiGateway::Stage':
-        if stage["methodSettings"] and "loggingLevel" in stage["methodSettings"]["*/*"]:
+        if stage["methodSettings"]:
             for method in stage["methodSettings"]:
-                #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
+                #Scenario 2: If at least one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
                 if stage["methodSettings"][method]["loggingLevel"] not in valid_rule_parameters:
                     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
             #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
@@ -85,11 +85,10 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
 
     #Resource Type AWS::ApiGatewayV2::Stage
     if stage["defaultRouteSettings"]["loggingLevel"] in valid_rule_parameters:
-         #Scenario 3:  If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
+         #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
         return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
-    #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
+    #Scenario 2: If at least one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
-
 
 def evaluate_parameters(rule_parameters):
 
@@ -99,7 +98,7 @@ def evaluate_parameters(rule_parameters):
         list_rule_parameters = [rule_parameter.strip() for rule_parameter in rule_parameters['loggingLevel'].split(',')]
         for each_parameter in list_rule_parameters:
             if each_parameter not in ALLOWED_LOGGING_LEVEL_VALUES:
-                raise ValueError('Logging Level: '+each_parameter + ' is not a valid logging level.')
+                raise ValueError('Logging Level: ' + each_parameter + ' is not a valid logging level.')
         valid_rule_parameters = list_rule_parameters
     return valid_rule_parameters
 

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -1,0 +1,369 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+'''
+
+#####################################
+##           Gherkin               ##
+#####################################
+Rule Name:
+    API_GW_EXECUTION_LOGGING_ENABLED
+
+Description:
+  Checks that methods in an Amazon API Gateway stage for deployed APIs have 'loggingLevel' as one of the values specified in the rule parameter 'loggingLevel'. The rule returns NON_COMPLIANT if any method in a stage has 'loggingLevel' set to a value not matching any of the logging levels specified in the rule parameter.
+
+Trigger:
+  Configuration Change on AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
+
+Reports on:
+  AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
+
+Rule Parameters:
+  loggingLevel
+  (Optional) Comma-separated list of allowed logging levels. Default is "ERROR,INFO"
+
+Scenarios:
+  Scenario: 1
+    Given: The rule parameter is invalid
+     Then: Return ERROR
+  Scenario: 2
+    Given: The rule parameter is valid
+       And: In the Stage configuration item, atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter.
+     Then: Return NON_COMPLIANT
+  Scenario: 3
+    Given: The rule parameter is valid
+       And: In the Stage configuration item, all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter.
+     Then: Return COMPLIANT
+'''
+
+import json
+import sys
+import datetime
+import boto3
+import botocore
+
+try:
+    import liblogging
+except ImportError:
+    pass
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::ApiGateway::Stage'
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (useful for cross-account).
+ASSUME_ROLE_MODE = False
+
+# Other parameters (no change needed)
+CONFIG_ROLE_TIMEOUT_SECONDS = 900
+
+DEFAULT_LOGGING_LEVEL = ["ERROR", "INFO"]
+ALLOWED_LOGGING_LEVEL_VALUES = ["ERROR", "INFO", "OFF"]
+
+#############
+# Main Code #
+#############
+
+def evaluate_compliance(event, configuration_item, valid_rule_parameters):
+
+    resource_type = configuration_item['resourceType']
+    stage = configuration_item['configuration']
+
+    #Resource Type AWS::ApiGateway::Stage
+    if resource_type == 'AWS::ApiGateway::Stage':
+        if stage["methodSettings"] and "loggingLevel" in stage["methodSettings"]["*/*"]:
+            for method in stage["methodSettings"]:
+                #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
+                if stage["methodSettings"][method]["loggingLevel"] not in valid_rule_parameters:
+                    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
+            #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
+            return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
+        return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
+
+    #Resource Type AWS::ApiGatewayV2::Stage
+    if  stage["defaultRouteSettings"]["loggingLevel"] in valid_rule_parameters:
+         #Scenario 3:  If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
+        return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
+    #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
+    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
+
+
+def evaluate_parameters(rule_parameters):
+
+    valid_rule_parameters = DEFAULT_LOGGING_LEVEL
+    #Scenario 1: The rule parameter is invalid
+    if "loggingLevel" in rule_parameters:
+        list_rule_parameters = rule_parameters['loggingLevel'].split(',')
+        for each_parameter in list_rule_parameters:
+            if each_parameter not in ALLOWED_LOGGING_LEVEL_VALUES:
+                raise ValueError('Logging Level: '+each_parameter)
+        valid_rule_parameters = list_rule_parameters
+    return valid_rule_parameters
+
+####################
+# Helper Functions #
+####################
+
+def build_parameters_value_error_response(ex):
+    return  build_error_response(internal_error_message="Parameter value is invalid",
+                                 internal_error_details="An ValueError was raised during the validation of the Parameter value",
+                                 customer_error_code="InvalidParameterValueException",
+                                 customer_error_message=str(ex))
+
+def get_client(service, event):
+
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service)
+    credentials = get_assume_role_credentials(event["executionRoleArn"])
+    return boto3.client(service, aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken']
+                       )
+
+def build_evaluation(resource_id, compliance_type, event, resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    eval_cc = {}
+    if annotation:
+        eval_cc['Annotation'] = annotation
+    eval_cc['ComplianceResourceType'] = resource_type
+    eval_cc['ComplianceResourceId'] = resource_id
+    eval_cc['ComplianceType'] = compliance_type
+    eval_cc['OrderingTimestamp'] = str(json.loads(event['invokingEvent'])['notificationCreationTime'])
+    return eval_cc
+
+def build_evaluation_from_config_item(configuration_item, compliance_type, annotation=None):
+    eval_ci = {}
+    if annotation:
+        eval_ci['Annotation'] = annotation
+    eval_ci['ComplianceResourceType'] = configuration_item['resourceType']
+    eval_ci['ComplianceResourceId'] = configuration_item['resourceId']
+    eval_ci['ComplianceType'] = compliance_type
+    eval_ci['OrderingTimestamp'] = configuration_item['configurationItemCaptureTime']
+    return eval_ci
+
+####################
+# Boilerplate Code #
+####################
+
+def check_defined(reference, reference_name):
+    if not reference:
+        raise Exception('Error: ', reference_name, 'is not defined')
+    return reference
+
+def is_oversized_changed_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'OversizedConfigurationItemChangeNotification'
+
+def is_scheduled_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'ScheduledNotification'
+
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1)
+    configuration_item = result['configurationItems'][0]
+    return convert_api_configuration(configuration_item)
+
+def convert_api_configuration(configuration_item):
+    for k, v in configuration_item.items():
+        if isinstance(v, datetime.datetime):
+            configuration_item[k] = str(v)
+    configuration_item['awsAccountId'] = configuration_item['accountId']
+    configuration_item['ARN'] = configuration_item['arn']
+    configuration_item['configurationStateMd5Hash'] = configuration_item['configurationItemMD5Hash']
+    configuration_item['configurationItemVersion'] = configuration_item['version']
+    configuration_item['configuration'] = json.loads(configuration_item['configuration'])
+    if 'relationships' in configuration_item:
+        for i in range(len(configuration_item['relationships'])):
+            configuration_item['relationships'][i]['name'] = configuration_item['relationships'][i]['relationshipName']
+    return configuration_item
+
+def get_configuration_item(invoking_event):
+    check_defined(invoking_event, 'invokingEvent')
+    if is_oversized_changed_notification(invoking_event['messageType']):
+        configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
+        return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
+    elif is_scheduled_notification(invoking_event['messageType']):
+        return None
+    return check_defined(invoking_event['configurationItem'], 'configurationItem')
+
+def is_applicable(configuration_item, event):
+    try:
+        check_defined(configuration_item, 'configurationItem')
+        check_defined(event, 'event')
+    except:
+        return True
+    status = configuration_item['configurationItemStatus']
+    event_left_scope = event['eventLeftScope']
+    if status == 'ResourceDeleted':
+        print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
+    return (status == 'OK' or status == 'ResourceDiscovered') and not event_left_scope
+
+def get_assume_role_credentials(role_arn):
+    sts_client = boto3.client('sts')
+    try:
+        assume_role_response = sts_client.assume_role(RoleArn=role_arn,
+                                                      RoleSessionName="configLambdaExecution",
+                                                      DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)
+        if 'liblogging' in sys.modules:
+            liblogging.logSession(role_arn, assume_role_response)
+        return assume_role_response['Credentials']
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        print(str(ex))
+        if 'AccessDenied' in ex.response['Error']['Code']:
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response['Error']['Message'] = "InternalError"
+            ex.response['Error']['Code'] = "InternalError"
+        raise ex
+
+def clean_up_old_evaluations(latest_evaluations, event):
+
+    cleaned_evaluations = []
+
+    old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+        ConfigRuleName=event['configRuleName'],
+        ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+        Limit=100)
+
+    old_eval_list = []
+
+    while True:
+        for old_result in old_eval['EvaluationResults']:
+            old_eval_list.append(old_result)
+        if 'NextToken' in old_eval:
+            next_token = old_eval['NextToken']
+            old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+                ConfigRuleName=event['configRuleName'],
+                ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+                Limit=100,
+                NextToken=next_token)
+        else:
+            break
+
+    for old_eval in old_eval_list:
+        old_resource_id = old_eval['EvaluationResultIdentifier']['EvaluationResultQualifier']['ResourceId']
+        newer_founded = False
+        for latest_eval in latest_evaluations:
+            if old_resource_id == latest_eval['ComplianceResourceId']:
+                newer_founded = True
+        if not newer_founded:
+            cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
+
+    return cleaned_evaluations + latest_evaluations
+
+def lambda_handler(event, context):
+    if 'liblogging' in sys.modules:
+        liblogging.logEvent(event)
+
+    global AWS_CONFIG_CLIENT
+
+    #print(event)
+    check_defined(event, 'event')
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = {}
+    if 'ruleParameters' in event:
+        rule_parameters = json.loads(event['ruleParameters'])
+
+    try:
+        valid_rule_parameters = evaluate_parameters(rule_parameters)
+    except ValueError as ex:
+        return build_parameters_value_error_response(ex)
+
+    try:
+        AWS_CONFIG_CLIENT = get_client('config', event)
+        if invoking_event['messageType'] in ['ConfigurationItemChangeNotification', 'ScheduledNotification', 'OversizedConfigurationItemChangeNotification']:
+            configuration_item = get_configuration_item(invoking_event)
+            if is_applicable(configuration_item, event):
+                compliance_result = evaluate_compliance(event, configuration_item, valid_rule_parameters)
+            else:
+                compliance_result = "NOT_APPLICABLE"
+        else:
+            return build_internal_error_response('Unexpected message type', str(invoking_event))
+    except botocore.exceptions.ClientError as ex:
+        if is_internal_error(ex):
+            return build_internal_error_response("Unexpected error while completing API request", str(ex))
+        return build_error_response("Customer error while making API request", str(ex), ex.response['Error']['Code'], ex.response['Error']['Message'])
+    except ValueError as ex:
+        return build_internal_error_response(str(ex), str(ex))
+
+    evaluations = []
+    latest_evaluations = []
+
+    if not compliance_result:
+        latest_evaluations.append(build_evaluation(event['accountId'], "NOT_APPLICABLE", event, resource_type='AWS::::Account'))
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, str):
+        if configuration_item:
+            evaluations.append(build_evaluation_from_config_item(configuration_item, compliance_result))
+        else:
+            evaluations.append(build_evaluation(event['accountId'], compliance_result, event, resource_type=DEFAULT_RESOURCE_TYPE))
+    elif isinstance(compliance_result, list):
+        for evaluation in compliance_result:
+            missing_fields = False
+            for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+                if field not in evaluation:
+                    print("Missing " + field + " from custom evaluation.")
+                    missing_fields = True
+
+            if not missing_fields:
+                latest_evaluations.append(evaluation)
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, dict):
+        missing_fields = False
+        for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+            if field not in compliance_result:
+                print("Missing " + field + " from custom evaluation.")
+                missing_fields = True
+        if not missing_fields:
+            evaluations.append(compliance_result)
+    else:
+        evaluations.append(build_evaluation_from_config_item(configuration_item, 'NOT_APPLICABLE'))
+
+    # Put together the request that reports the evaluation status
+    result_token = event['resultToken']
+    test_mode = False
+    if result_token == 'TESTMODE':
+        # Used solely for RDK test to skip actual put_evaluation API call
+        test_mode = True
+
+    # Invoke the Config API to report the result of the evaluation
+    evaluation_copy = []
+    evaluation_copy = evaluations[:]
+    while evaluation_copy:
+        AWS_CONFIG_CLIENT.put_evaluations(Evaluations=evaluation_copy[:100], ResultToken=result_token, TestMode=test_mode)
+        del evaluation_copy[:100]
+
+    # Used solely for RDK test to be able to test Lambda function
+    return evaluations
+
+def is_internal_error(exception):
+    return ((not isinstance(exception, botocore.exceptions.ClientError)) or exception.response['Error']['Code'].startswith('5')
+            or 'InternalError' in exception.response['Error']['Code'] or 'ServiceError' in exception.response['Error']['Code'])
+
+def build_internal_error_response(internal_error_message, internal_error_details=None):
+    return build_error_response(internal_error_message, internal_error_details, 'InternalError', 'InternalError')
+
+def build_error_response(internal_error_message, internal_error_details=None, customer_error_code=None, customer_error_message=None):
+    error_response = {
+        'internalErrorMessage': internal_error_message,
+        'internalErrorDetails': internal_error_details,
+        'customerErrorMessage': customer_error_message,
+        'customerErrorCode': customer_error_code
+    }
+    print(error_response)
+    return error_response

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -10,12 +10,26 @@
 # the specific language governing permissions and limitations under the License.
 
 '''
+<<<<<<< HEAD
+=======
 
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 #####################################
 ##           Gherkin               ##
 #####################################
 Rule Name:
     API_GW_EXECUTION_LOGGING_ENABLED
+<<<<<<< HEAD
+Description:
+  Checks that methods in an Amazon API Gateway stage for deployed APIs have 'loggingLevel' as one of the values specified in the rule parameter 'loggingLevel'. The rule returns NON_COMPLIANT if any method in a stage has 'loggingLevel' set to a value not matching any of the logging levels specified in the rule parameter.
+Trigger:
+  Configuration Change on AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
+Reports on:
+  AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
+Rule Parameters:
+  loggingLevel
+  (Optional) Comma-separated list of allowed logging levels. Default is "ERROR,INFO"
+=======
 
 Description:
   Checks that methods in an Amazon API Gateway stage for deployed APIs have 'loggingLevel' as one of the values specified in the rule parameter 'loggingLevel'. The rule returns NON_COMPLIANT if any method in a stage has 'loggingLevel' set to a value not matching any of the logging levels specified in the rule parameter.
@@ -30,6 +44,7 @@ Rule Parameters:
   loggingLevel
   (Optional) Comma-separated list of allowed logging levels. Default is "ERROR,INFO"
 
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 Scenarios:
   Scenario: 1
     Given: The rule parameter is invalid
@@ -86,17 +101,30 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
             for method in stage["methodSettings"]:
                 #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
                 if stage["methodSettings"][method]["loggingLevel"] not in valid_rule_parameters:
+<<<<<<< HEAD
+                    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
+            #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
+            return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
+        if "OFF" in valid_rule_parameters:
+            return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
+        return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
+=======
                     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
             #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
             return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
         return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 
     #Resource Type AWS::ApiGatewayV2::Stage
     if  stage["defaultRouteSettings"]["loggingLevel"] in valid_rule_parameters:
          #Scenario 3:  If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
         return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
     #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
+<<<<<<< HEAD
+    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
+=======
     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 
 
 def evaluate_parameters(rule_parameters):
@@ -107,7 +135,11 @@ def evaluate_parameters(rule_parameters):
         list_rule_parameters = rule_parameters['loggingLevel'].split(',')
         for each_parameter in list_rule_parameters:
             if each_parameter not in ALLOWED_LOGGING_LEVEL_VALUES:
+<<<<<<< HEAD
+                raise ValueError('Logging Level: '+each_parameter + 'is not a valid logging level.')
+=======
                 raise ValueError('Logging Level: '+each_parameter)
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         valid_rule_parameters = list_rule_parameters
     return valid_rule_parameters
 

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -10,16 +10,11 @@
 # the specific language governing permissions and limitations under the License.
 
 '''
-<<<<<<< HEAD
-=======
-
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 #####################################
 ##           Gherkin               ##
 #####################################
 Rule Name:
     API_GW_EXECUTION_LOGGING_ENABLED
-<<<<<<< HEAD
 Description:
   Checks that methods in an Amazon API Gateway stage for deployed APIs have 'loggingLevel' as one of the values specified in the rule parameter 'loggingLevel'. The rule returns NON_COMPLIANT if any method in a stage has 'loggingLevel' set to a value not matching any of the logging levels specified in the rule parameter.
 Trigger:
@@ -29,22 +24,6 @@ Reports on:
 Rule Parameters:
   loggingLevel
   (Optional) Comma-separated list of allowed logging levels. Default is "ERROR,INFO"
-=======
-
-Description:
-  Checks that methods in an Amazon API Gateway stage for deployed APIs have 'loggingLevel' as one of the values specified in the rule parameter 'loggingLevel'. The rule returns NON_COMPLIANT if any method in a stage has 'loggingLevel' set to a value not matching any of the logging levels specified in the rule parameter.
-
-Trigger:
-  Configuration Change on AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
-
-Reports on:
-  AWS::ApiGateway::Stage or AWS::ApiGatewayV2::Stage
-
-Rule Parameters:
-  loggingLevel
-  (Optional) Comma-separated list of allowed logging levels. Default is "ERROR,INFO"
-
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 Scenarios:
   Scenario: 1
     Given: The rule parameter is invalid
@@ -101,30 +80,19 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
             for method in stage["methodSettings"]:
                 #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
                 if stage["methodSettings"][method]["loggingLevel"] not in valid_rule_parameters:
-<<<<<<< HEAD
                     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
             #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
             return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
         if "OFF" in valid_rule_parameters:
             return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
         return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
-=======
-                    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
-            #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
-            return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
-        return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 
     #Resource Type AWS::ApiGatewayV2::Stage
     if  stage["defaultRouteSettings"]["loggingLevel"] in valid_rule_parameters:
          #Scenario 3:  If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
         return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
     #Scenario 2: If atleast one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
-<<<<<<< HEAD
     return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
-=======
-    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'API Stage: '+stage['stageName']+' doesn\'t have required logging level enabled.')
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
 
 
 def evaluate_parameters(rule_parameters):
@@ -135,11 +103,7 @@ def evaluate_parameters(rule_parameters):
         list_rule_parameters = rule_parameters['loggingLevel'].split(',')
         for each_parameter in list_rule_parameters:
             if each_parameter not in ALLOWED_LOGGING_LEVEL_VALUES:
-<<<<<<< HEAD
                 raise ValueError('Logging Level: '+each_parameter + 'is not a valid logging level.')
-=======
-                raise ValueError('Logging Level: '+each_parameter)
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         valid_rule_parameters = list_rule_parameters
     return valid_rule_parameters
 

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED.py
@@ -80,17 +80,17 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
                     methods_logging_not_enabled.append(method)
             if methods_logging_not_enabled:
                 #Scenario 2: If at least one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
-                return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + ' for the following method(s): [' + ', '.join(methods_logging_not_enabled) + '].')
+                return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging Level does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + ' in this Amazon API Gateway Stage for the following method(s): [' + ', '.join(methods_logging_not_enabled) + '].')
             #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
             return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
-        return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging is not configured for this API Gateway Stage.')
+        return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging is not configured for this Amazon API Gateway Stage.')
 
     #Resource Type AWS::ApiGatewayV2::Stage
     if stage["defaultRouteSettings"]["loggingLevel"] in valid_rule_parameters:
          #Scenario 3: If all methods in 'methodSettings' have the 'loggingLevel' set to a value in rule parameter return compliant.
         return build_evaluation_from_config_item(configuration_item, 'COMPLIANT')
     #Scenario 2: If at least one method in 'methodSettings' has the 'loggingLevel' set to a value not in rule parameter return non_compliant.
-    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + '.')
+    return build_evaluation_from_config_item(configuration_item, 'NON_COMPLIANT', 'Logging Level does not match the value for rule parameter (loggingLevel): ' + str(valid_rule_parameters) + ' in this Amazon API Gateway Stage.')
 
 def evaluate_parameters(rule_parameters):
     valid_rule_parameters = ALLOWED_LOGGING_LEVEL_VALUES

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -36,45 +36,54 @@ RULE = __import__('API_GW_EXECUTION_LOGGING_ENABLED')
 
 class ParameterTest(unittest.TestCase):
 
-    invoking_event_parameter_test_1 = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
-    invoking_event_parameter_test_2 = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
-    invoking_event_non_compliant = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'INFO', 'updatedValue': 'OFF', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+    stage_settings_1 = {
+        'methodSettings':{
+            '*/*':{
+                'loggingLevel':'OFF',
+                'dataTraceEnabled':False
+            }
+        }
+    }
+    stage_settings_2 = {
+        'methodSettings':{
+            '*/*':{
+                'loggingLevel':'INFO',
+                'dataTraceEnabled':False
+            }
+        }
+    }
 
      #Scenario 1: Rule Parameter is invalid
     def test_invalid_param_value(self):
         rule_parameters = '{"loggingLevel": "SOMETHING"}'
+        invoking_event = build_invoking_event(self.stage_settings_1, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         assert_customer_error_response(self, response, 'InvalidParameterValueException')
 
     def test_invalid_parameter_values2(self):
         rule_parameters = '{"loggingLevel": "ERROR,NO"}'
+        invoking_event = build_invoking_event(self.stage_settings_1, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         assert_customer_error_response(self, response, 'InvalidParameterValueException')
 
     #Scenario 2: Non Compliant
     def test_no_parameter_non_compliant(self):
         rule_parameters = '{}'
+        invoking_event = build_invoking_event(self.stage_settings_1, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_non_compliant, rule_parameters), {})
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant
-    def test_no_parameter_complaint_1(self):
+    def test_no_parameter_compliant(self):
         rule_parameters = '{}'
+        invoking_event = build_invoking_event(self.stage_settings_2, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
-        resp_expected = []
-        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
-        assert_successful_evaluation(self, response, resp_expected)
-
-    def test_no_parameter_compliant_2(self):
-        rule_parameters = '{}'
-        RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_2, rule_parameters), {})
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
         resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
         assert_successful_evaluation(self, response, resp_expected)
@@ -85,26 +94,52 @@ class LoggingLevelTest(unittest.TestCase):
 
     #Scenario 2: Non compliant for Resource Type AWS::ApiGateway::Stage
     def test_logging_level_overriden_off(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.~1test~1{proxy}/GET': {'previousValue': None, 'updatedValue': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}, 'changeType': 'CREATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Apr 10, 2019 7:29:25 AM', 'updatedValue': 'Apr 13, 2019 6:06:01 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': 'tex2hz', 'stageName': 'limit', 'cacheClusterEnabled': False, 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'~1test~1{proxy}/GET': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}, '*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': True, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': False, 'createdDate': 'Feb 21, 2019 8:10:53 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:06:01 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:06:02.230Z', 'configurationStateId': 1555178762230, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'resourceName': 'limit', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-02-21T08:10:53.890Z'}, 'notificationCreationTime': '2019-04-13T18:06:02.935Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'methodSettings':{
+                '~1test~1{proxy}/GET':{
+                    'loggingLevel':'OFF',
+                    'dataTraceEnabled':False
+                },
+                '*/*':{
+                    'loggingLevel':'INFO',
+                    'dataTraceEnabled':True
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
-        print(response)
         resp_expected = []
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_non_compliant(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'methodSettings':{
+                '*/*':{
+                    'loggingLevel':'INFO',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         rule_parameters = '{"loggingLevel": "ERROR"}'
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
-        print(response)
         resp_expected = []
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_non_compliant(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'methodSettings':{
+                '*/*':{
+                    'loggingLevel':'ERROR',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         rule_parameters = '{"loggingLevel": "INFO"}'
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
@@ -115,7 +150,15 @@ class LoggingLevelTest(unittest.TestCase):
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
     def test_logging_level_info(self):
-        invoking_event = '{ "configurationItem": {"relatedEvents": [], "relationships": [{"resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh", "resourceName": "cache-edge", "resourceType": "AWS::ApiGateway::RestApi", "name": "Is contained in "}], "configuration": {"deploymentId": "jtemac", "stageName": "test",  "cacheClusterSize": "0.5", "cacheClusterStatus": "AVAILABLE", "methodSettings": {"*/*": { "loggingLevel": "INFO",   "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}, "~1elastic~1dug/GET": { "loggingLevel": "INFO",  "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}}, "createdDate": "Nov 23, 2018 4:15:40 AM", "lastUpdatedDate": "Nov 23, 2018 4:59:33 AM"}, "supplementaryConfiguration": {}, "tags": {}, "configurationItemVersion": "1.3", "configurationItemCaptureTime": "2019-03-20T04:54:41.388Z", "awsAccountId": "123456789012", "configurationItemStatus": "ResourceDiscovered", "resourceType": "AWS::ApiGateway::Stage", "resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "resourceName": "test", "ARN": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "awsRegion": "us-east-1", "availabilityZone": "Not Applicable", "configurationStateMd5Hash": "", "resourceCreationTime": "2018-11-23T04:15:40.744Z"}, "notificationCreationTime": "2019-04-11T10:46:59.236Z", "messageType": "ConfigurationItemChangeNotification", "recordVersion": "1.3"}'
+        stage_settings = {
+            'methodSettings':{
+                '*/*':{
+                    'loggingLevel':'INFO',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
@@ -123,7 +166,15 @@ class LoggingLevelTest(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error(self):
-        invoking_event = '{ "configurationItem": {"relatedEvents": [], "relationships": [{"resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh", "resourceName": "cache-edge", "resourceType": "AWS::ApiGateway::RestApi", "name": "Is contained in "}], "configuration": {"deploymentId": "jtemac", "stageName": "test",  "cacheClusterSize": "0.5", "cacheClusterStatus": "AVAILABLE", "methodSettings": {"*/*": { "loggingLevel": "ERROR",   "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}, "~1elastic~1dug/GET": { "loggingLevel": "ERROR",  "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}}, "createdDate": "Nov 23, 2018 4:15:40 AM", "lastUpdatedDate": "Nov 23, 2018 4:59:33 AM"}, "supplementaryConfiguration": {}, "tags": {}, "configurationItemVersion": "1.3", "configurationItemCaptureTime": "2019-03-20T04:54:41.388Z", "awsAccountId": "123456789012", "configurationItemStatus": "ResourceDiscovered", "resourceType": "AWS::ApiGateway::Stage", "resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "resourceName": "test", "ARN": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "awsRegion": "us-east-1", "availabilityZone": "Not Applicable", "configurationStateMd5Hash": "", "resourceCreationTime": "2018-11-23T04:15:40.744Z"}, "notificationCreationTime": "2019-04-11T10:46:59.236Z", "messageType": "ConfigurationItemChangeNotification", "recordVersion": "1.3"}'
+        stage_settings = {
+            'methodSettings':{
+                '*/*':{
+                    'loggingLevel':'ERROR',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
@@ -131,37 +182,53 @@ class LoggingLevelTest(unittest.TestCase):
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_compliant(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'methodSettings':{
+                '~1test~1{proxy}/GET':{
+                    'loggingLevel':'INFO',
+                    'dataTraceEnabled':False
+                },
+                '*/*':{
+                    'loggingLevel':'INFO',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         rule_parameters = '{"loggingLevel": "INFO"}'
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
-        print(response)
         resp_expected = []
         resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_compliant(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'methodSettings':{
+                '*/*':{
+                    'loggingLevel':'ERROR',
+                    'dataTraceEnabled':False
+                }
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         rule_parameters = '{"loggingLevel": "ERROR"}'
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
-        print(response)
         resp_expected = []
         resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 2: Non Compliant for Resource Type AWS::ApiGatewayV2::Stage
-    def test_apiv2_create_loglevel_with_off(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {}, 'changeType': 'CREATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'config4', 'deploymentId': 'j8k0k8', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:47 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:47 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:47.488Z', 'configurationStateId': 1555175927488, 'awsAccountId': '123456789012', 'configurationItemStatus': 'ResourceDiscovered', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'resourceName': 'config4', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:47.262Z'}, 'notificationCreationTime': '2019-04-13T17:18:47.730Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
-        RULE.ASSUME_ROLE_MODE = False
-        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
-        resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
-        assert_successful_evaluation(self, response, resp_expected)
-
     def test_apiv2_change_loglevel_to_off(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.defaultRouteSettings.loggingLevel': {'previousValue': 'INFO', 'updatedValue': 'OFF', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'test', 'deploymentId': 'fncu8d', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:04 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:04 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:24.496Z', 'configurationStateId': 1555175904496, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:04.479Z'}, 'notificationCreationTime': '2019-04-13T17:18:24.828Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'defaultRouteSettings':{
+                'loggingLevel':'OFF',
+                'dataTraceEnabled':False,
+            },
+        }
         RULE.ASSUME_ROLE_MODE = False
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGatewayV2::Stage', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test')
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
@@ -169,7 +236,13 @@ class LoggingLevelTest(unittest.TestCase):
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage
     def test_apiv2_change_loglevel_to_info(self):
-        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.defaultRouteSettings.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'test', 'deploymentId': 'fncu8d', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:04 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:04 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:21.693Z', 'configurationStateId': 1555175901693, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:04.479Z'}, 'notificationCreationTime': '2019-04-13T17:18:21.899Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        stage_settings = {
+            'defaultRouteSettings':{
+                'loggingLevel':'INFO',
+                'dataTraceEnabled':False
+            }
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGatewayV2::Stage', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
@@ -180,6 +253,21 @@ class LoggingLevelTest(unittest.TestCase):
 ####################
 # Helper Functions #
 ####################
+
+def build_invoking_event(stage_settings, resource_type, resource_id):
+    invoking_event_to_return = {
+        'configurationItem':{
+            'configuration':stage_settings,
+            'configurationItemStatus':'OK',
+            'configurationItemCaptureTime':'2019-04-13T17:18:21.693Z',
+            'resourceType':resource_type,
+            'resourceId':resource_id,
+            'resourceName':'test',
+            'ARN':resource_id
+            },
+        'messageType':'ConfigurationItemChangeNotification'
+        }
+    return json.dumps(invoking_event_to_return)
 
 def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
     event_to_return = {

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -73,7 +73,7 @@ class ParameterTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] for the following method(s): [*/*].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] in this Amazon API Gateway Stage for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant
@@ -98,7 +98,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging is not configured for this API Gateway Stage.'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging is not configured for this Amazon API Gateway Stage.'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_overriden_off(self):
@@ -116,7 +116,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] for the following method(s): [~1test~1{proxy}/GET].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging Level does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] in this Amazon API Gateway Stage for the following method(s): [~1test~1{proxy}/GET].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_non_compliant(self):
@@ -132,7 +132,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'] for the following method(s): [*/*].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level does not match the value for rule parameter (loggingLevel): [\'ERROR\'] in this Amazon API Gateway Stage for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_non_compliant(self):
@@ -149,7 +149,7 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'INFO\'] for the following method(s): [*/*].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level does not match the value for rule parameter (loggingLevel): [\'INFO\'] in this Amazon API Gateway Stage for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
@@ -229,7 +229,7 @@ class LoggingLevelTest(unittest.TestCase):
         invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGatewayV2::Stage', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test')
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'Logging Level does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] in this Amazon API Gateway Stage.'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -26,7 +26,7 @@ class Boto3Mock():
     def client(client_name, *args, **kwargs):
         if client_name == 'config':
             return CONFIG_CLIENT_MOCK
-        elif client_name == 'sts':
+        if client_name == 'sts':
             return STS_CLIENT_MOCK
         else:
             raise Exception("Attempting to create an unknown client")

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -39,30 +39,28 @@ class ParameterTest(unittest.TestCase):
     stage_settings_1 = {
         'methodSettings':{
             '*/*':{
-                'loggingLevel':'OFF',
-                'dataTraceEnabled':False
+                'loggingLevel':'OFF'
             }
         }
     }
     stage_settings_2 = {
         'methodSettings':{
             '*/*':{
-                'loggingLevel':'INFO',
-                'dataTraceEnabled':False
+                'loggingLevel':'INFO'
             }
         }
     }
 
-     #Scenario 1: Rule Parameter is invalid
+    #Scenario 1: Rule Parameter is invalid
     def test_invalid_param_value(self):
-        rule_parameters = '{"loggingLevel": "SOMETHING"}'
+        rule_parameters = '{"loggingLevel": "INVALID"}'
         invoking_event = build_invoking_event(self.stage_settings_1, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         assert_customer_error_response(self, response, 'InvalidParameterValueException')
 
     def test_invalid_parameter_values2(self):
-        rule_parameters = '{"loggingLevel": "ERROR,NO"}'
+        rule_parameters = '{"loggingLevel": "ERROR,NOTSET"}'
         invoking_event = build_invoking_event(self.stage_settings_1, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test')
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
@@ -88,21 +86,29 @@ class ParameterTest(unittest.TestCase):
         resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
         assert_successful_evaluation(self, response, resp_expected)
 
-
 class LoggingLevelTest(unittest.TestCase):
     rule_parameters = '{"loggingLevel": "ERROR,INFO"}'
 
     #Scenario 2: Non compliant for Resource Type AWS::ApiGateway::Stage
+    def test_logging_level_default_off(self):
+        stage_settings = {
+            'methodSettings':{}
+        }
+        invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGateway::Stage', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit')
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        assert_successful_evaluation(self, response, resp_expected)
+
     def test_logging_level_overriden_off(self):
         stage_settings = {
             'methodSettings':{
                 '~1test~1{proxy}/GET':{
-                    'loggingLevel':'OFF',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'OFF'
                 },
                 '*/*':{
-                    'loggingLevel':'INFO',
-                    'dataTraceEnabled':True
+                    'loggingLevel':'INFO'
                 }
             }
         }
@@ -117,8 +123,7 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '*/*':{
-                    'loggingLevel':'INFO',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'INFO'
                 }
             }
         }
@@ -134,8 +139,7 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '*/*':{
-                    'loggingLevel':'ERROR',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'ERROR'
                 }
             }
         }
@@ -153,8 +157,7 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '*/*':{
-                    'loggingLevel':'INFO',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'INFO'
                 }
             }
         }
@@ -169,8 +172,7 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '*/*':{
-                    'loggingLevel':'ERROR',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'ERROR'
                 }
             }
         }
@@ -185,12 +187,10 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '~1test~1{proxy}/GET':{
-                    'loggingLevel':'INFO',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'INFO'
                 },
                 '*/*':{
-                    'loggingLevel':'INFO',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'INFO'
                 }
             }
         }
@@ -206,8 +206,7 @@ class LoggingLevelTest(unittest.TestCase):
         stage_settings = {
             'methodSettings':{
                 '*/*':{
-                    'loggingLevel':'ERROR',
-                    'dataTraceEnabled':False
+                    'loggingLevel':'ERROR'
                 }
             }
         }
@@ -223,8 +222,7 @@ class LoggingLevelTest(unittest.TestCase):
     def test_apiv2_change_loglevel_to_off(self):
         stage_settings = {
             'defaultRouteSettings':{
-                'loggingLevel':'OFF',
-                'dataTraceEnabled':False,
+                'loggingLevel':'OFF'
             },
         }
         RULE.ASSUME_ROLE_MODE = False
@@ -238,8 +236,7 @@ class LoggingLevelTest(unittest.TestCase):
     def test_apiv2_change_loglevel_to_info(self):
         stage_settings = {
             'defaultRouteSettings':{
-                'loggingLevel':'INFO',
-                'dataTraceEnabled':False
+                'loggingLevel':'INFO'
             }
         }
         invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGatewayV2::Stage', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test')
@@ -248,7 +245,6 @@ class LoggingLevelTest(unittest.TestCase):
         resp_expected = []
         resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage'))
         assert_successful_evaluation(self, response, resp_expected)
-
 
 ####################
 # Helper Functions #

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -28,8 +28,7 @@ class Boto3Mock():
             return CONFIG_CLIENT_MOCK
         if client_name == 'sts':
             return STS_CLIENT_MOCK
-        else:
-            raise Exception("Attempting to create an unknown client")
+        raise Exception("Attempting to create an unknown client")
 
 sys.modules['boto3'] = Boto3Mock()
 

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -1,0 +1,287 @@
+import sys
+import unittest
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+import json
+import botocore
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::ApiGateway::RestApi'
+
+#############
+# Main Code #
+#############
+
+CONFIG_CLIENT_MOCK = MagicMock()
+STS_CLIENT_MOCK = MagicMock()
+
+class Boto3Mock():
+    @staticmethod
+    def client(client_name, *args, **kwargs):
+        if client_name == 'config':
+            return CONFIG_CLIENT_MOCK
+        elif client_name == 'sts':
+            return STS_CLIENT_MOCK
+        else:
+            raise Exception("Attempting to create an unknown client")
+
+sys.modules['boto3'] = Boto3Mock()
+
+RULE = __import__('API_GW_EXECUTION_LOGGING_ENABLED')
+
+class ParameterTest(unittest.TestCase):
+
+    invoking_event_parameter_test_1 = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+    invoking_event_parameter_test_2 = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+    invoking_event_non_compliant = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'INFO', 'updatedValue': 'OFF', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+
+     #Scenario 1: Rule Parameter is invalid
+    def test_invalid_param_value(self):
+        rule_parameters = '{"loggingLevel": "SOMETHING"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
+        assert_customer_error_response(self, response, 'InvalidParameterValueException')
+
+    def test_invalid_parameter_values2(self):
+        rule_parameters = '{"loggingLevel": "ERROR,NO"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
+        assert_customer_error_response(self, response, 'InvalidParameterValueException')
+
+    #Scenario 2: Non Compliant
+    def test_no_parameter_non_compliant(self):
+        rule_parameters = '{}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_non_compliant, rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Scenario 3: Compliant
+    def test_no_parameter_complaint_1(self):
+        rule_parameters = '{}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_1, rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_no_parameter_compliant_2(self):
+        rule_parameters = '{}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_parameter_test_2, rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+
+class LoggingLevelTest(unittest.TestCase):
+    rule_parameters = '{"loggingLevel": "ERROR,INFO"}'
+
+    #Scenario 2: Non compliant for Resource Type AWS::ApiGateway::Stage
+    def test_logging_level_overriden_off(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.~1test~1{proxy}/GET': {'previousValue': None, 'updatedValue': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}, 'changeType': 'CREATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Apr 10, 2019 7:29:25 AM', 'updatedValue': 'Apr 13, 2019 6:06:01 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': 'tex2hz', 'stageName': 'limit', 'cacheClusterEnabled': False, 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'~1test~1{proxy}/GET': {'metricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}, '*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': True, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': False, 'createdDate': 'Feb 21, 2019 8:10:53 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:06:01 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:06:02.230Z', 'configurationStateId': 1555178762230, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'resourceName': 'limit', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-02-21T08:10:53.890Z'}, 'notificationCreationTime': '2019-04-13T18:06:02.935Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        print(response)
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'API Stage: limit doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_logging_level_info_non_compliant(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        rule_parameters = '{"loggingLevel": "ERROR"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+        print(response)
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_logging_level_error_non_compliant(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        rule_parameters = '{"loggingLevel": "INFO"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+        print(response)
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
+    def test_logging_level_info(self):
+        invoking_event = '{ "configurationItem": {"relatedEvents": [], "relationships": [{"resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh", "resourceName": "cache-edge", "resourceType": "AWS::ApiGateway::RestApi", "name": "Is contained in "}], "configuration": {"deploymentId": "jtemac", "stageName": "test",  "cacheClusterSize": "0.5", "cacheClusterStatus": "AVAILABLE", "methodSettings": {"*/*": { "loggingLevel": "INFO",   "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}, "~1elastic~1dug/GET": { "loggingLevel": "INFO",  "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}}, "createdDate": "Nov 23, 2018 4:15:40 AM", "lastUpdatedDate": "Nov 23, 2018 4:59:33 AM"}, "supplementaryConfiguration": {}, "tags": {}, "configurationItemVersion": "1.3", "configurationItemCaptureTime": "2019-03-20T04:54:41.388Z", "awsAccountId": "123456789012", "configurationItemStatus": "ResourceDiscovered", "resourceType": "AWS::ApiGateway::Stage", "resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "resourceName": "test", "ARN": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "awsRegion": "us-east-1", "availabilityZone": "Not Applicable", "configurationStateMd5Hash": "", "resourceCreationTime": "2018-11-23T04:15:40.744Z"}, "notificationCreationTime": "2019-04-11T10:46:59.236Z", "messageType": "ConfigurationItemChangeNotification", "recordVersion": "1.3"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_logging_level_error(self):
+        invoking_event = '{ "configurationItem": {"relatedEvents": [], "relationships": [{"resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh", "resourceName": "cache-edge", "resourceType": "AWS::ApiGateway::RestApi", "name": "Is contained in "}], "configuration": {"deploymentId": "jtemac", "stageName": "test",  "cacheClusterSize": "0.5", "cacheClusterStatus": "AVAILABLE", "methodSettings": {"*/*": { "loggingLevel": "ERROR",   "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}, "~1elastic~1dug/GET": { "loggingLevel": "ERROR",  "unauthorizedCacheControlHeaderStrategy": "SUCCEED_WITH_RESPONSE_HEADER"}}, "createdDate": "Nov 23, 2018 4:15:40 AM", "lastUpdatedDate": "Nov 23, 2018 4:59:33 AM"}, "supplementaryConfiguration": {}, "tags": {}, "configurationItemVersion": "1.3", "configurationItemCaptureTime": "2019-03-20T04:54:41.388Z", "awsAccountId": "123456789012", "configurationItemStatus": "ResourceDiscovered", "resourceType": "AWS::ApiGateway::Stage", "resourceId": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "resourceName": "test", "ARN": "arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test", "awsRegion": "us-east-1", "availabilityZone": "Not Applicable", "configurationStateMd5Hash": "", "resourceCreationTime": "2018-11-23T04:15:40.744Z"}, "notificationCreationTime": "2019-04-11T10:46:59.236Z", "messageType": "ConfigurationItemChangeNotification", "recordVersion": "1.3"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/asdf567gh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_logging_level_info_compliant(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        rule_parameters = '{"loggingLevel": "INFO"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+        print(response)
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_logging_level_error_compliant(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.methodSettings.*/*.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'ERROR', 'changeType': 'UPDATE'}, 'Configuration.lastUpdatedDate': {'previousValue': 'Dec 12, 2018 9:01:20 AM', 'updatedValue': 'Apr 13, 2019 6:04:37 PM', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh', 'resourceName': 'resource1', 'resourceType': 'AWS::ApiGateway::RestApi', 'name': 'Is contained in '}], 'configuration': {'deploymentId': '0r280l', 'stageName': 'test', 'cacheClusterEnabled': False, 'cacheClusterSize': '0.5', 'cacheClusterStatus': 'NOT_AVAILABLE', 'methodSettings': {'*/*': {'metricsEnabled': False, 'loggingLevel': 'ERROR', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0, 'cachingEnabled': False, 'cacheTtlInSeconds': 300, 'cacheDataEncrypted': False, 'requireAuthorizationForCacheControl': True, 'unauthorizedCacheControlHeaderStrategy': 'SUCCEED_WITH_RESPONSE_HEADER'}}, 'tracingEnabled': True, 'createdDate': 'Dec 4, 2018 10:09:21 AM', 'lastUpdatedDate': 'Apr 13, 2019 6:04:37 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T18:04:37.523Z', 'configurationStateId': 1555178677523, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGateway::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2018-12-04T10:09:21.128Z'}, 'notificationCreationTime': '2019-04-13T18:04:37.840Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        rule_parameters = '{"loggingLevel": "ERROR"}'
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
+        print(response)
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Scenario 2: Non Compliant for Resource Type AWS::ApiGatewayV2::Stage
+    def test_apiv2_create_loglevel_with_off(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {}, 'changeType': 'CREATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'config4', 'deploymentId': 'j8k0k8', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:47 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:47 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:47.488Z', 'configurationStateId': 1555175927488, 'awsAccountId': '123456789012', 'configurationItemStatus': 'ResourceDiscovered', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'resourceName': 'config4', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:47.262Z'}, 'notificationCreationTime': '2019-04-13T17:18:47.730Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'API Stage: config4 doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    def test_apiv2_change_loglevel_to_off(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.defaultRouteSettings.loggingLevel': {'previousValue': 'INFO', 'updatedValue': 'OFF', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'test', 'deploymentId': 'fncu8d', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'OFF', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:04 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:04 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:24.496Z', 'configurationStateId': 1555175904496, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:04.479Z'}, 'notificationCreationTime': '2019-04-13T17:18:24.828Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage
+    def test_apiv2_change_loglevel_to_info(self):
+        invoking_event = json.dumps({'configurationItemDiff': {'changedProperties': {'Configuration.defaultRouteSettings.loggingLevel': {'previousValue': 'OFF', 'updatedValue': 'INFO', 'changeType': 'UPDATE'}}, 'changeType': 'UPDATE'}, 'configurationItem': {'relatedEvents': [], 'relationships': [{'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu', 'resourceName': 'My Chat API-WebSocket', 'resourceType': 'AWS::ApiGatewayV2::Api', 'name': 'Is contained in '}], 'configuration': {'stageName': 'test', 'deploymentId': 'fncu8d', 'defaultRouteSettings': {'detailedMetricsEnabled': False, 'loggingLevel': 'INFO', 'dataTraceEnabled': False, 'throttlingBurstLimit': 5000, 'throttlingRateLimit': 10000.0}, 'routeSettings': {}, 'stageVariables': {}, 'createdDate': 'Apr 13, 2019 5:18:04 PM', 'lastUpdatedDate': 'Apr 13, 2019 5:18:04 PM'}, 'supplementaryConfiguration': {}, 'tags': {}, 'configurationItemVersion': '1.3', 'configurationItemCaptureTime': '2019-04-13T17:18:21.693Z', 'configurationStateId': 1555175901693, 'awsAccountId': '123456789012', 'configurationItemStatus': 'OK', 'resourceType': 'AWS::ApiGatewayV2::Stage', 'resourceId': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'resourceName': 'test', 'ARN': 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'awsRegion': 'us-east-1', 'availabilityZone': 'Not Applicable', 'configurationStateMd5Hash': '', 'resourceCreationTime': '2019-04-13T17:18:04.479Z'}, 'notificationCreationTime': '2019-04-13T17:18:21.899Z', 'messageType': 'ConfigurationItemChangeNotification', 'recordVersion': '1.3'})
+        RULE.ASSUME_ROLE_MODE = False
+        response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
+        resp_expected = []
+        resp_expected.append(build_expected_response('COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+
+####################
+# Helper Functions #
+####################
+
+def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_lambda_scheduled_event(rule_parameters=None):
+    invoking_event = '{"messageType":"ScheduledNotification","notificationCreationTime":"2017-12-23T22:11:18.158Z"}'
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_expected_response(compliance_type, compliance_resource_id, compliance_resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    if not annotation:
+        return {
+            'ComplianceType': compliance_type,
+            'ComplianceResourceId': compliance_resource_id,
+            'ComplianceResourceType': compliance_resource_type
+            }
+    return {
+        'ComplianceType': compliance_type,
+        'ComplianceResourceId': compliance_resource_id,
+        'ComplianceResourceType': compliance_resource_type,
+        'Annotation': annotation
+        }
+
+def assert_successful_evaluation(test_class, response, resp_expected, evaluations_count=1):
+    if isinstance(response, dict):
+        test_class.assertEquals(resp_expected['ComplianceResourceType'], response['ComplianceResourceType'])
+        test_class.assertEquals(resp_expected['ComplianceResourceId'], response['ComplianceResourceId'])
+        test_class.assertEquals(resp_expected['ComplianceType'], response['ComplianceType'])
+        test_class.assertTrue(response['OrderingTimestamp'])
+        if 'Annotation' in resp_expected or 'Annotation' in response:
+            test_class.assertEquals(resp_expected['Annotation'], response['Annotation'])
+    elif isinstance(response, list):
+        test_class.assertEquals(evaluations_count, len(response))
+        for i, response_expected in enumerate(resp_expected):
+            test_class.assertEquals(response_expected['ComplianceResourceType'], response[i]['ComplianceResourceType'])
+            test_class.assertEquals(response_expected['ComplianceResourceId'], response[i]['ComplianceResourceId'])
+            test_class.assertEquals(response_expected['ComplianceType'], response[i]['ComplianceType'])
+            test_class.assertTrue(response[i]['OrderingTimestamp'])
+            if 'Annotation' in response_expected or 'Annotation' in response[i]:
+                test_class.assertEquals(response_expected['Annotation'], response[i]['Annotation'])
+
+def assert_customer_error_response(test_class, response, customer_error_code=None, customer_error_message=None):
+    if customer_error_code:
+        test_class.assertEqual(customer_error_code, response['customerErrorCode'])
+    if customer_error_message:
+        test_class.assertEqual(customer_error_message, response['customerErrorMessage'])
+    test_class.assertTrue(response['customerErrorCode'])
+    test_class.assertTrue(response['customerErrorMessage'])
+    if "internalErrorMessage" in response:
+        test_class.assertTrue(response['internalErrorMessage'])
+    if "internalErrorDetails" in response:
+        test_class.assertTrue(response['internalErrorDetails'])
+
+def sts_mock():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string"}}
+    STS_CLIENT_MOCK.reset_mock(return_value=True)
+    STS_CLIENT_MOCK.assume_role = MagicMock(return_value=assume_role_response)
+
+##################
+# Common Testing #
+##################
+
+class TestStsErrors(unittest.TestCase):
+
+    def test_sts_unknown_error(self):
+        RULE.ASSUME_ROLE_MODE = True
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'unknown-code', 'Message': 'unknown-message'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'InternalError', 'InternalError')
+
+    def test_sts_access_denied(self):
+        RULE.ASSUME_ROLE_MODE = True
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'AccessDenied', 'AWS Config does not have permission to assume the IAM role.')

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -73,7 +73,7 @@ class ParameterTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant
@@ -98,7 +98,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging is not configured for this API Gateway Stage.'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_overriden_off(self):
@@ -116,7 +116,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'] for the following method(s): [~1test~1{proxy}/GET].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_non_compliant(self):
@@ -132,7 +132,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'] for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_non_compliant(self):
@@ -149,7 +149,7 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'INFO\'] for the following method(s): [*/*].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
@@ -229,7 +229,7 @@ class LoggingLevelTest(unittest.TestCase):
         invoking_event = build_invoking_event(stage_settings, 'AWS::ApiGatewayV2::Stage', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test')
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'Logging Level of this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -59,11 +59,7 @@ class ParameterTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_non_compliant, rule_parameters), {})
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant
@@ -94,11 +90,7 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         print(response)
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'API Stage: limit doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_non_compliant(self):
@@ -108,11 +100,7 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_non_compliant(self):
@@ -122,11 +110,7 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'INFO\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
@@ -172,11 +156,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'API Stage: config4 doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_apiv2_change_loglevel_to_off(self):
@@ -184,11 +164,7 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
-<<<<<<< HEAD
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
-=======
-        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
->>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/API_GW_EXECUTION_LOGGING_ENABLED_test.py
@@ -59,7 +59,11 @@ class ParameterTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_non_compliant, rule_parameters), {})
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant
@@ -90,7 +94,11 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         print(response)
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/limit', 'AWS::ApiGateway::Stage', 'API Stage: limit doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_info_non_compliant(self):
@@ -100,7 +108,11 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_logging_level_error_non_compliant(self):
@@ -110,7 +122,11 @@ class LoggingLevelTest(unittest.TestCase):
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, rule_parameters), {})
         print(response)
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'INFO\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/restapis/abcd123fgh/stages/test', 'AWS::ApiGateway::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGateway::Stage
@@ -156,7 +172,11 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/config4', 'AWS::ApiGatewayV2::Stage', 'API Stage: config4 doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_apiv2_change_loglevel_to_off(self):
@@ -164,7 +184,11 @@ class LoggingLevelTest(unittest.TestCase):
         RULE.ASSUME_ROLE_MODE = False
         response = RULE.lambda_handler(build_lambda_configurationchange_event(invoking_event, self.rule_parameters), {})
         resp_expected = []
+<<<<<<< HEAD
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'The Logging Level for this API Gateway Stage does not match the value for rule parameter (loggingLevel): [\'ERROR\', \'INFO\'].'))
+=======
         resp_expected.append(build_expected_response('NON_COMPLIANT', 'arn:aws:apigateway:us-east-1::/apis/qwert123yu/stages/test', 'AWS::ApiGatewayV2::Stage', 'API Stage: test doesn\'t have required logging level enabled.'))
+>>>>>>> 21cd6e1dd0187b62c74d06cde4eff8b07461ceb5
         assert_successful_evaluation(self, response, resp_expected)
 
     #Scenario 3: Compliant for Resource Type AWS::ApiGatewayV2::Stage

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
@@ -4,7 +4,7 @@
     "RuleName": "API_GW_EXECUTION_LOGGING_ENABLED",
     "SourceRuntime": "python3.6",
     "CodeKey": "API_GW_EXECUTION_LOGGING_ENABLED.zip",
-    "InputParameters": "{\"loggingLevel\": \"ERROR,INFO\"}",
+    "InputParameters": "{}",
     "OptionalParameters": "{\"loggingLevel\": \"\"}",
     "SourceEvents": "AWS::ApiGateway::Stage,AWS::ApiGatewayV2::Stage"
   },

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
@@ -5,7 +5,7 @@
     "SourceRuntime": "python3.6",
     "CodeKey": "API_GW_EXECUTION_LOGGING_ENABLED.zip",
     "InputParameters": "{\"loggingLevel\": \"ERROR,INFO\"}",
-    "OptionalParameters": "{}",
+    "OptionalParameters": "{\"loggingLevel\": \"\"}",
     "SourceEvents": "AWS::ApiGateway::Stage,AWS::ApiGatewayV2::Stage"
   },
   "Tags": "[]"

--- a/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
+++ b/python/API_GW_EXECUTION_LOGGING_ENABLED/parameters.json
@@ -1,0 +1,12 @@
+{
+  "Version": "1.0",
+  "Parameters": {
+    "RuleName": "API_GW_EXECUTION_LOGGING_ENABLED",
+    "SourceRuntime": "python3.6",
+    "CodeKey": "API_GW_EXECUTION_LOGGING_ENABLED.zip",
+    "InputParameters": "{\"loggingLevel\": \"ERROR,INFO\"}",
+    "OptionalParameters": "{}",
+    "SourceEvents": "AWS::ApiGateway::Stage,AWS::ApiGatewayV2::Stage"
+  },
+  "Tags": "[]"
+}


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
https://github.com/awslabs/aws-config-rules/issues/191

*Description of changes:*
Adding rule API_GW_EXECUTION_LOGGING_ENABLED