### PR TITLE
Pylintrc modified to limit length of module name

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -155,10 +155,10 @@ class-rgx=[A-Z_][a-zA-Z0-9_]+$
 class-name-hint=[A-Z_][a-zA-Z0-9_]+$
 
 # Regular expression matching correct module names
-module-rgx=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Za-z](_test)?)$
+module-rgx=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Z0-9](_test)?)$
 
 # Naming hint for module names
-module-name-hint=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Za-z](_test)?)$
+module-name-hint=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Z0-9](_test)?)$
 
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{5,}$

--- a/python/pylintrc
+++ b/python/pylintrc
@@ -155,10 +155,10 @@ class-rgx=[A-Z_][a-zA-Z0-9_]+$
 class-name-hint=[A-Z_][a-zA-Z0-9_]+$
 
 # Regular expression matching correct module names
-module-rgx=[A-Z][A-Z_0-9]+[A-Z0-9](_test)?$
+module-rgx=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Za-z](_test)?)$
 
 # Naming hint for module names
-module-name-hint=[A-Z][A-Z_0-9]+[A-Z0-9](_test)?$
+module-name-hint=(?=.{2,128}$)([A-Z][A-Z_0-9]+[A-Za-z](_test)?)$
 
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{5,}$


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

Description of changes: As per CloudFormation limit on the name of the stack of 128 characters, included a limit for length of the rule name.
