### PR TITLE
Fix the "configurationItemSummary" when invoking event

### DIFF
--- a/python/s3_bucket_default_encryption_enabled.py
+++ b/python/s3_bucket_default_encryption_enabled.py
@@ -133,7 +133,7 @@ def lambda_handler(event, context):
     # Check for oversized item
     if "configurationItem" in invoking_event:
         configuration_item = invoking_event["configurationItem"]
-    elif "configurationItemSummary" in invokingEvent:
+    elif "configurationItemSummary" in invoking_event:
         configuration_item = invoking_event["configurationItemSummary"]
 
     # Optional parameters


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
