### PR TITLE
Update ec2_desired_instance_type.py

### DIFF
--- a/python/ec2_desired_instance_type.py
+++ b/python/ec2_desired_instance_type.py
@@ -26,8 +26,8 @@ def evaluate_compliance(config_item, rule_parameters):
     if (config_item['resourceType'] != 'AWS::EC2::Instance'):
         return 'NOT_APPLICABLE'
 
-    elif (config_item['configuration']['instanceType'] ==
-            rule_parameters['desiredInstanceType']):
+    elif (config_item['configuration']['instanceType'] in
+            rule_parameters['desiredInstanceType'].split(','):
         return 'COMPLIANT'
     else:
         return 'NON_COMPLIANT'


### PR DESCRIPTION
Allow parameter "desiredInstanceType" to be a list of instance types.

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
Currently parameter can only contain a single instance type.

*Description of changes:*
