### PR TITLE
Add support for IP permission descriptions

### DIFF
--- a/python/ec2_security_group_ingress.py
+++ b/python/ec2_security_group_ingress.py
@@ -60,7 +60,7 @@ REQUIRED_PERMISSIONS = [
     "FromPort" : 80,
     "ToPort" : 80,
     "UserIdGroupPairs" : [],
-    "IpRanges" : [{"CidrIp" : "0.0.0.0/0"}],
+    "IpRanges" : [{"CidrIp" : "0.0.0.0/0", "Description": ""}],
     "PrefixListIds" : [],
     "Ipv6Ranges" : []
 },
@@ -69,7 +69,7 @@ REQUIRED_PERMISSIONS = [
     "FromPort" : 443,
     "ToPort" : 443,
     "UserIdGroupPairs" : [],
-    "IpRanges" : [{"CidrIp" : "0.0.0.0/0"}],
+    "IpRanges" : [{"CidrIp" : "0.0.0.0/0", "Description": ""}],
     "PrefixListIds" : [],
     "Ipv6Ranges" : []
 }]


### PR DESCRIPTION
Modified data structures to include support of permission descriptions for IP CIDRs in security groups.

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
