### PR TITLE
Added Rule to check EC2 Instances against Qualys REST API

### DIFF
--- a/python/EC2_Qualys_Reporting_Status/AWS Config Rule - EC2 Qualys Agent Reporting Status.html
+++ b/python/EC2_Qualys_Reporting_Status/AWS Config Rule - EC2 Qualys Agent Reporting Status.html
@@ -1,0 +1,833 @@
+<!doctype html>
+<html><head><title>AWS Config Rule - EC2 Qualys Agent Reporting Status</title><meta charset="UTF-8"><link href="http://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,700,700italic|Roboto:400,700,700italic,400italic" rel="stylesheet" type="text/css"><style>/*
+ * Copyright 2014 Quip
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+body {
+    font-size: 15px;
+    color: #333;
+    background: white;
+    padding: 60px 95px;
+    max-width: 900px;
+    margin: 0 auto;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: "kern";
+    font-kerning: normal;
+    -moz-font-feature-settings: "kern";
+    -webkit-font-feature-settings: "kern";
+}
+
+/* Headings */
+h1,
+h2,
+h3,
+th {
+    font-family: Roboto, sans-serif;
+    font-weight: 700;
+    margin: 0;
+    margin-top: 1.25em;
+    margin-bottom: 0.75em;
+}
+
+h1 {
+    font-size: 35px;
+    line-height: 42px;
+}
+
+h1:first-child {
+    margin-top: 0;
+}
+
+h2 {
+    font-size: 18px;
+    line-height: 22px;
+}
+
+h3 {
+    font-size: 13px;
+    line-height: 16px;
+}
+
+.capitalize-h3 h3 {
+    text-transform: uppercase;
+}
+
+/* Body text */
+body,
+p,
+ul,
+ol,
+td {
+    font-family: "Crimson Text", serif;
+    font-size: 16px;
+    line-height: 20px;
+}
+
+blockquote,
+q {
+    display: block;
+    margin: 1em 0;
+    font-style: italic;
+}
+
+blockquote a,
+q a {
+    text-decoration: underline;
+}
+
+blockquote {
+    padding-left: 10px;
+    border-left: 4px solid #a6a6a6;
+}
+
+q {
+    color: #a6a6a6;
+    line-height: 40px;
+    font-size: 24px;
+    text-align: center;
+    quotes: none;
+}
+
+q a {
+    color: #a6a6a6;
+}
+
+code,
+pre {
+    font-family: Consolas, "Liberation Mono", Menlo, "Courier Prime Web",
+        Courier, monospace;
+    background: #f2f2f2;
+}
+
+code {
+    padding: 1px;
+    margin: 0 -1px;
+    border-radius: 3px;
+}
+
+pre {
+    display: block;
+    line-height: 20px;
+    text-shadow: 0 1px white;
+    padding: 5px 5px 5px 30px;
+    white-space: nowrap;
+    position: relative;
+    margin: 1em 0;
+}
+
+pre:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 15px;
+    border-left: solid 1px #dadada;
+}
+
+/* Lists */
+div[data-section-style="5"],
+div[data-section-style="6"],
+div[data-section-style="7"] {
+    margin: 12px 0;
+}
+
+ul {
+    padding: 0 0 0 40px;
+}
+
+ul li {
+    margin-bottom: 0.4em;
+}
+
+/* Bulleted list */
+div[data-section-style="5"] ul {
+    list-style-type: disc;
+}
+div[data-section-style="5"] ul ul {
+    list-style-type: circle;
+}
+div[data-section-style="5"] ul ul ul {
+    list-style-type: square;
+}
+div[data-section-style="5"] ul ul ul ul {
+    list-style-type: disc;
+}
+div[data-section-style="5"] ul ul ul ul ul {
+    list-style-type: circle;
+}
+div[data-section-style="5"] ul ul ul ul ul ul {
+    list-style-type: square;
+}
+
+/* Numbered list */
+div[data-section-style="6"] ul {
+    list-style-type: decimal;
+}
+div[data-section-style="6"] ul ul {
+    list-style-type: lower-alpha;
+}
+div[data-section-style="6"] ul ul ul {
+    list-style-type: lower-roman;
+}
+div[data-section-style="6"] ul ul ul ul {
+    list-style-type: decimal;
+}
+div[data-section-style="6"] ul ul ul ul ul {
+    list-style-type: lower-alpha;
+}
+div[data-section-style="6"] ul ul ul ul ul ul {
+    list-style-type: lower-roman;
+}
+
+/* Checklist */
+div[data-section-style="7"] ul {
+    list-style-type: none;
+}
+
+div[data-section-style="7"] ul li:before {
+    content: "\2610";
+    position: absolute;
+    display: inline;
+    margin-right: 1.2em;
+    margin-left: -1.2em;
+}
+
+div[data-section-style="7"] ul li.parent:before {
+    content: "";
+}
+
+div[data-section-style="7"] ul li.checked {
+    text-decoration: line-through;
+}
+
+div[data-section-style="7"] ul li.checked:before {
+    content: "\2611";
+    text-decoration: none;
+}
+
+/* Tables */
+div[data-section-style="8"] {
+    margin: 12px 0;
+}
+
+table {
+    border-spacing: 0;
+    border-collapse: separate;
+    border: solid 1px #bbb;
+    table-layout: fixed;
+    position: relative;
+}
+
+table th,
+table td {
+    padding: 2px 2px 0;
+    min-width: 1.5em;
+    word-wrap: break-word;
+}
+
+table th {
+    border-bottom: 1px solid #c7cbd1;
+    background: #f2f2f2;
+    font-weight: bold;
+    vertical-align: bottom;
+    color: #3a4449;
+    text-align: center;
+}
+
+table td {
+    padding-top: 0;
+    border-left: 1px solid #c7cbd1;
+    border-top: 1px solid #c7cbd1;
+    vertical-align: top;
+}
+
+table td.bold {
+    font-weight: bold;
+}
+
+table td.italic {
+    font-style: italic;
+}
+
+table td.underline {
+    text-decoration: underline;
+}
+
+table td.strikethrough {
+    text-decoration: line-through;
+}
+
+table td.underline.strikethrough {
+    text-decoration: underline line-through;
+}
+
+table td:first-child {
+    border-left: hidden;
+}
+
+table tr:first-child td {
+    border-top: hidden;
+}
+
+/* Images */
+div[data-section-style="11"] {
+    margin-top: 20px;
+    margin-bottom: 20px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+div[data-section-style="11"][data-section-float="0"] {
+    clear: both;
+    text-align: center;
+}
+
+div[data-section-style="11"][data-section-float="1"] {
+    float: left;
+    clear: left;
+    margin-right: 20px;
+}
+
+div[data-section-style="11"][data-section-float="2"] {
+    float: right;
+    clear: right;
+    margin-left: 20px;
+}
+
+div[data-section-style="11"] img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: auto;
+}
+
+hr {
+    width: 70px;
+    margin: 20px auto;
+}
+
+/* Apps */
+div[data-section-style="19"].placeholder {
+    margin: 0.8em auto;
+    padding: 4px 0;
+    display: block;
+    color: #3d87f5;
+    text-align: center;
+    border: 1px solid rgba(41, 182, 242, 0.2);
+    border-radius: 3px;
+    background: #e9f8fe;
+    font-family: Roboto, sans-serif;
+}
+
+div[data-section-style="19"].first-party-element {
+    margin-bottom: 10px;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+div[data-section-style="19"].first-party-element.kanban {
+    background-image: url("https://quip-cdn.com/nK0hSyhsb4jrLIL2s5Ma-g");
+    height: 166px;
+}
+
+div[data-section-style="19"].first-party-element.calendar {
+    background-image: url("https://quip-cdn.com/OYujqLny03RILxcLIiyERg");
+    height: 244px;
+}
+
+div[data-section-style="19"].first-party-element.poll {
+    background-image: url("https://quip-cdn.com/fbIiFrcKGv__4NB7CBfxoA");
+    height: 116px;
+}
+
+div[data-section-style="19"].first-party-element.countdown {
+    background-image: url("https://quip-cdn.com/3bPhykD2dBei9sSjCWteTQ");
+    height: 96px;
+}
+
+div[data-section-style="19"].first-party-element.process_bar {
+    background-image: url("https://quip-cdn.com/ybQlHnHEIIBLog5rZmYs_w");
+    height: 36px;
+}
+
+div[data-section-style="19"].first-party-element.project_tracker {
+    background-image: url("https://quip-cdn.com/OFQU087b4Mxzz1ZaHwtjXA");
+    height: 164px;
+}
+
+div[data-section-style="19"] img {
+    margin: 0.5em;
+}
+
+div[data-section-style="19"] img.masked-image {
+    margin: 0;
+    transform-origin: top left;
+}
+
+div[data-section-style="19"] .image-mask {
+    position: relative;
+    overflow: hidden;
+}
+/*
+ * Copyright 2019 Quip
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+body {
+    counter-reset: indent0 indent1 indent2 indent3 indent4 indent5 indent6
+        indent7 indent8;
+}
+
+/* Numbered list */
+div[data-section-style="6"] {
+    counter-reset: indent0 indent1 indent2 indent3 indent4 indent5 indent6
+        indent7 indent8;
+}
+div[data-section-style="6"].list-numbering-continue {
+    counter-reset: none;
+}
+div[data-section-style="6"].list-numbering-restart-at {
+    counter-reset: indent0 var(--indent0) indent1 indent2 indent3 indent4
+        indent5 indent6 indent7 indent8;
+}
+div[data-section-style="6"] ul {
+    /* indent0 is not reset since it is shared across the div elements */
+    list-style-type: none !important;
+}
+div[data-section-style="6"] ul ul {
+    counter-reset: indent1;
+}
+div[data-section-style="6"] ul ul ul {
+    counter-reset: indent2;
+}
+div[data-section-style="6"] ul ul ul ul {
+    counter-reset: indent3;
+}
+div[data-section-style="6"] ul ul ul ul ul {
+    counter-reset: indent4;
+}
+div[data-section-style="6"] ul ul ul ul ul ul {
+    counter-reset: indent5;
+}
+div[data-section-style="6"] ul li {
+    counter-increment: indent0;
+}
+div[data-section-style="6"] ul ul li {
+    counter-increment: indent1;
+}
+div[data-section-style="6"] ul ul ul li {
+    counter-increment: indent2;
+}
+div[data-section-style="6"] ul ul ul ul li {
+    counter-increment: indent3;
+}
+div[data-section-style="6"] ul ul ul ul ul li {
+    counter-increment: indent4;
+}
+div[data-section-style="6"] ul ul ul ul ul ul li {
+    counter-increment: indent5;
+}
+div[data-section-style="6"] ul li:before {
+    content: counter(indent0, decimal) ". ";
+}
+div[data-section-style="6"] ul ul li:before {
+    content: counter(indent1, lower-alpha) ". ";
+}
+div[data-section-style="6"] ul ul ul li:before {
+    content: counter(indent2, lower-roman) ". ";
+}
+div[data-section-style="6"] ul ul ul ul li:before {
+    content: counter(indent3, decimal) ". ";
+}
+div[data-section-style="6"] ul ul ul ul ul li:before {
+    content: counter(indent4, lower-alpha) ". ";
+}
+div[data-section-style="6"] ul ul ul ul ul ul li:before {
+    content: counter(indent5, lower-roman) ". ";
+}
+</style></head><body><h1 id='SDC9CALxUqn'>AWS Config Rule - EC2 Qualys Agent Reporting Status</h1>
+
+<br/>
+
+The following guide aims to assist on deploying a custom AWS Config Rule that leverages third party REST APIs (Qualys) to evaluate AWS Resources in an automated fashion. <br/>
+
+<br/>
+
+<h3 id='SDC9CAngAnO'>Problem to be solved:</h3>
+
+AWS Config continuously monitors and records your AWS resource configurations and allows you to automate the evaluation of recorded configurations against desired configurations, unfortunately sometimes these desired configurations require customers to evaluate third party solutions that do not reside within the Services in AWS. <br/>
+
+<br/>
+
+Using the Rule Development Kit (RDK) and AWS Services such as AWS Config, Secrets Manager and Key Management Service (KMS) we can orchestrate these evaluations.<br/>
+
+<h3 id='SDC9CA1yNRz'>Design considerations:</h3>
+
+The code provided along with this guide will require you to have administrator access to multiple services, each one of them has a step-by-step setup process in this guide. <br/>
+
+<h3 id='SDC9CAhE7Ta'>High-Level Requirements:</h3>
+
+In order to make the most out of this guide it is recommended to know basic Python and understand some programming concepts such as functions and variables.<br/>
+
+<h3 id='SDC9CATFS20'>Use cases and user stories:</h3>
+
+The code used in this guide shows how to integrate a third party REST API that requires XML structures while leveraging AWS’ own APIs that use JSON structures. The concept behind this walk-through is that multiple services can be integrated into AWS Config to generate a custom evaluation, regardless of whether they’re part of the AWS Services or not.<br/>
+
+<br/>
+
+<b>User Stories:</b> <br/>
+
+<div data-section-style='5' class="" style=""><ul id='SDC9CAe99fy'><li id='SDC9CAwtkuF' class='' value='1'>“As a Security Analyst, I would like a way to granularly define AWS Config Rules so that I can get a concise view/report that shows me an asset's compliance status based on my security standards”  
+
+<br/></li><li id='SDC9CAxASRP' class=''>“As a Security Manager, I would like a simple, automated view, that showed me and my peers what resources we have in AWS and their current status against our multiple security solutions” 
+
+<br/></li></ul></div><h3 id='SDC9CAm7gkx'>High-level architecture and design</h3>
+
+In order to deploy this or similar rules you will need to have the <a href="https://github.com/awslabs/aws-config-rdk">Rule Development Kit (RDK) </a>installed in your development environment and deployed on your AWS Account. <br/>
+
+<br/>
+
+For example, the code in this guide was created with the following command:<br/>
+
+<code>rdk create EC2_Qualys_Reporting_Status --runtime python3.7 —maximum-frequency TwentyFour_Hours</code><br/>
+
+<h3 id='SDC9CAk0odt'>Important Dependencies and Potential Blockers:</h3>
+
+You will need to have a minimum set of permissions in AWS in order to use RDK, Secrets Manager or KMS<br/>
+
+<h3 id='SDC9CAxm5dE'><span bgcolor="#fce2cf" style="background-color:#fce2cf"><u>Update the code according to your environment</u></span></h3>
+
+<b>Lines 245-250 </b>specify the Secrets Manager Details used to retrieve your Qualys Credentials.<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/LB0KqBNGIY1w_cfcFoOgZw?a=g8PTWt3tKzBtOkfFtelO71ZASE8KLbzPsG2YsN3vMDUa' id='SDC9CA6c8BB' alt=''></img></div><br/>
+
+The “<b>platform</b>” variable defines your current Qualys API Server. <br/>
+
+Examples include: <br/>
+
+<div data-section-style='5' class="" style=""><ul id='SDC9CAg1RCO'><li id='SDC9CAJWrZQ' class='' value='1'><a href="http://qualysapi.qg3.apps.qualys.com">qualysapi.</a>qg2<a href="http://qualysapi.qg3.apps.qualys.com">.apps.qualys.com</a>
+
+<br/></li><li id='SDC9CASuBbN' class=''><a href="http://qualysapi.qg3.apps.qualys.com">qualysapi.</a>qg3<a href="http://qualysapi.qg3.apps.qualys.com">.apps.qualys.com</a>
+
+<br/></li><li id='SDC9CAF9JFZ' class=''> <a href="http://qualysapi.qg3.apps.qualys.com">qualysapi.</a>qg4<a href="http://qualysapi.qg3.apps.qualys.com">.apps.qualys.com</a>
+
+<br/></li></ul></div>See your Qualys Documentation to known which Qualys API Server to use.<br/>
+
+<br/>
+
+If you use a different URL format you’d need to update the “<b>qualys_query_instanceId</b>” function:<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/NNJ_sZp1bIKzg4e0tozjzA?a=qkN8Ll7YSCMgStfHQaNytUy1S7a30gmtAP7A8u3KNaQa' id='SDC9CAVAnvJ' alt=''></img></div><br/>
+
+The HOST variable inside this function specifies the Qualys API Server<br/>
+
+<br/>
+
+If you follow the steps in this guide you will only need to make sure your “<b>platform</b>” and “<b>region_name</b>” variables match your environment.<br/>
+
+<h1 id='SDC9CAogOkY'>Using this Custom AWS Config Rule</h1>
+
+The rule will evaluate EC2 Instances against the Qualys REST API. The purpose of this check is to see if the Instance has an agent installed and reporting back to Qualys.<br/>
+
+<br/>
+
+Here’s what the AWS Config Rule will look like once it’s been deployed:<br/>
+
+<br/>
+
+<b>Complaint Results:</b><br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/FkRBQ2nXe40zr1NoLVZOtQ?a=VmFmOKZwA7KjLKtom4alEaa5x6ovqmiiTk5ZjkUnLQQa' id='SDC9CA133Tf' alt='' width='800' height='317'></img></div><b>Noncompliant Results:</b><br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/KxHdIWbYzgS-U9zmYPVGbA?a=B4S2kZYg4XlEntOPvNByR0T0AwfmJGfdjLXNbgboJR4a' id='SDC9CAhGtnj' alt='' width='800' height='402'></img></div><br/>
+
+Due to the structure of the code and some security best practices, the rule will not be able to generate evaluations as soon as it’s deployed. You will need to follow this guide in order to remediate this.<br/>
+
+<br/>
+
+<h2 id='SDC9CAMkX01'>1. Deploy the rule using RDK</h2>
+
+Make sure rdk is configured on your account, you can check this by running the “rdk init“ command:<br/>
+
+<br/>
+
+<code>$ rdk init</code><br/>
+
+<code>Running init!</code><br/>
+
+<code>Found Config Recorder: default</code><br/>
+
+<code>Found Config Role: arn:aws:iam::123456789123:role/rdk/config-role</code><br/>
+
+<code>Found Bucket: config-bucket-123456789123</code><br/>
+
+<code>Config Service is ON</code><br/>
+
+<code>Config setup complete.</code><br/>
+
+<code>Found code bucket: config-rule-code-bucket-123456789123-us-east-1</code><br/>
+
+<br/>
+
+Next, make sure you’re on the directory where your RDK Rule folder is, if the RDK Rule Folder is named “QualysTESTRule” it should look like this:<br/>
+
+<br/>
+
+<code>$ ls</code><br/>
+
+<code>QualysTESTRule</code><br/>
+
+<code>$ ls -ahR QualysTESTRule/</code><br/>
+
+<code>. QualysTESTRule.py QualysTESTRule_test.py</code><br/>
+
+<code>.. parameters.json</code><br/>
+
+<br/>
+
+To deploy the rule use the rdk deploy command:<br/>
+
+<code>$ rdk deploy QualysTESTRule</code><br/>
+
+<code>Running deploy!</code><br/>
+
+<code>Found Custom Rule.</code><br/>
+
+<code>Zipping QualysTESTRule</code><br/>
+
+<code>Uploading QualysTESTRule</code><br/>
+
+<code>Upload complete.</code><br/>
+
+<code>Creating CloudFormation Stack for QualysTESTRule</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>Waiting for CloudFormation stack operation to complete...</code><br/>
+
+<code>CloudFormation stack operation complete.</code><br/>
+
+<code>Config deploy complete.</code><br/>
+
+<br/>
+
+<br/>
+
+<h3 id='SDC9CA4oecO'>Optional: Check the logs of the Custom Rule </h3>
+
+<br/>
+
+If you navigate to your AWS Config at this point you will see “No results reported“ for this Rule, if you click on the rule name it will take you to the Rule View. <br/>
+
+<br/>
+
+Click on Edit on the top right corner <br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/2EDwx1bGScP1V7e78GmUzA?a=eeJtqW7fgLQeKJBLCaSCp8b5hdl3ntiOmoGdauXfuqoa' id='SDC9CAFckxL' alt=''></img></div><br/>
+
+This will take you to the Rule Settings, since this is a custom rule, it uses a lambda with the RDK code we deployed.<br/>
+
+You can check the logs for this function by clicking on “Edit AWS Lambda function” in the main section of this window (under the <b>AWS Lambda function ARN*</b> field) <br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/PbxYrlEhi5lVZpl_sf8ZJw?a=RGNrft5aMjrIa3vomtGhqvjaQzMuGEX8LVbZsOBOKdUa' id='SDC9CAA25L4' alt=''></img></div><br/>
+
+From the lambda console you can click on the “Monitoring” Tab to see more details about the function<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/1QujmwfuuuARM7LI5KOAPg?a=4gwOoxIuYGTbHbXDoZkxQ076cjYAGdYh2nWW4zwTusAa' id='SDC9CAFyKeU' alt=''></img></div><br/>
+
+Near the top right corner of the Monitoring Tab you can see the “View logs in CloudWatch” button<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/GYWj-nxupzLAz_4YTdQYdg?a=97NjFbC19dDWBqwEaRGSFOOxZ4BNImFmE9BDlcDyE9Ya' id='SDC9CANa7vK' alt=''></img></div><br/>
+
+This will take you to CloudWatch where you can click on the latest Log stream and see details about the lambda execution<br/>
+
+<br/>
+
+Since we have not setup the Qualys Credentials in Secrets Manager or the required permissions for this lambda, the following error will show up in the logs:<br/>
+
+<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/ovF0oLFqAgntdfy4xzOwQQ?a=34WKZ13FcrS0cUnHWQEaoZjtjxmC5QBVXEy1Zw8L4owa' id='SDC9CATzKMh' alt='' width='800' height='186'></img></div>To remediate the error we need to follow the next steps in this guide.<br/>
+
+<h2 id='SDC9CAFgWwC'>2. Creating the Secret Managers Secret for Authentication</h2>
+
+<br/>
+
+Start by creating a Secret in Secrets Manager, this will be where our Qualys API Credentials will be stored<br/>
+
+<br/>
+
+From the Secrets Manager Console, select “Store a New Secret”.<br/>
+
+<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/fe1-5jMirZvfKogcFGq5XA?a=SoNisQWtVaWXox6MaulFuh6RbgqapXR4IAm6IRLXUA0a' id='SDC9CAML3Z3' alt=''></img></div><br/>
+
+<br/>
+
+Once you’re in the new secret page, select “Other type of secrets”<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/tW0q65OD224dzmkNg-nxAw?a=y30oY04SgDOiS98tojpDdG3ax4mvx8N8FPgy1a4TYlca' id='SDC9CAqNhE4' alt=''></img></div><br/>
+
+We’re using the following Key/Value structure:<br/>
+
+<div data-section-style='13'><table id='SDC9CAvXntf' title='Sheet1' style='width: 20.4em'><thead><tr><th class='empty' style='width: 2em'/><th id='SDC9CAsD6LI'  style='width: 9.06667em'>Secret Key
+
+<br/></th><th id='SDC9CAMTiZ8'  style='width: 11.3333em'>Secret Value
+
+<br/></th></tr></thead><tbody><tr id='SDC9CAezvNH'><td style='background-color:#f0f0f0'>1</td><td id='s:SDC9CAezvNH;SDC9CArkkRT' style=''>qualys_usr
+
+<br/></td><td id='s:SDC9CAezvNH;SDC9CA0rdOy' style=''>thisisyourusername
+
+<br/></td></tr><tr id='SDC9CAxlHD2'><td style='background-color:#f0f0f0'>2</td><td id='s:SDC9CAxlHD2;SDC9CArkkRT' style=''>qualys_pswrd
+
+<br/></td><td id='s:SDC9CAxlHD2;SDC9CA0rdOy' style=''>ABCDEFg1hIJKlmnOpQ#
+
+<br/></td></tr></tbody></table></div>So it should look like this:<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/EmgVfxXII2WeN8BZdsuwsg?a=JQOTRVrWuUmLWpURqPcQa0Aa1Yd6W7dPGaaPZtmq6eEa' id='SDC9CAecnyV' alt=''></img></div><br/>
+
+If you use a different Secret Key/Value structure, you’d need to update the code under the “<b>get_qualys_auth</b>” function so that the authorization returned (line 199) queries the right keys.<br/>
+
+<br/>
+
+You may create a new Encryption Key or use one of your previously created Customer Managed Keys<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/5OQ9qHk8se4dRX07qCK5Vg?a=hgaEAd8xYWtWO3hUE2dXHsazteQ5IateicRWQYBtTlAa' id='SDC9CAqJgcm' alt='' width='800' height='121'></img></div>We are naming this Secret “<b>QualysCredentials</b>”, if you decide to name it differently you will need to update the code accordingly (Line 246)<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/4zDAAkddTzZmMqwDzOmZHw?a=WwvQl2WVSUCbRQpFls0F0aNlXanWpf1SommEwEUkMx0a' id='SDC9CA7Ra9V' alt='' width='800' height='588'></img></div><br/>
+
+<h2 id='SDC9CAQ7m5R'>3. Creating the KMS CMK to En/Decrypt your Secrets</h2>
+
+<br/>
+
+Go to “Key Management Service (KMS)” in your AWS Console you can also get here from the previous step by selecting “<a href="https://us-east-1.console.aws.amazon.com/kms/home?region=us-east-1#/kms/keys">Add new key</a>”<br/>
+
+<br/>
+
+Select “Create Key”<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/zs544pVsJzgPpJIhxgZ3sw?a=zM7ydfDaJcRPhBaK0okgv2vne5FJgU4piogjOfdsgVQa' id='SDC9CAgwjms' alt=''></img></div><br/>
+
+In this example we’re creating a Symmetric Key with KMS generated Key Material as shown below:<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/7MRrmlqE2HWL2hhs90qtEg?a=RdTyR51gxbP9nsZ42NFBjxvjMawBmQROZKsv5hjJkUIa' id='SDC9CAOYXRt' alt='' width='798' height='529'></img></div><br/>
+
+You will need to specify an Alias for the key, fill out other information as necessary:<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/a-6yFzYoWolmEp7a8ZCjwA?a=tyFsE7WmNHBBa2MtlS93pAbXJOjN334JzesPLsVVWNca' id='SDC9CAX6n0F' alt=''></img></div><br/>
+
+<br/>
+
+You’d need to specify a Key Administrator, this will be the user that has Admin access over the key itself<br/>
+
+<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/vW1qOyWYqaM8AssQc3T5IQ?a=IgImlU3HgAaCVvMnud6f0y72Gkyrb5HBtrJtKst7JXka' id='SDC9CAcuMHR' alt='' width='797' height='572'></img></div>Next you will need to specify Access to use the Key by adding the Role for “AWSServiceRoleForConfig” to the list of users.<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/pszB4Ft_dNHwFV_YnckeTw?a=P1LDMX7luUOsJfMz8R274SA6FLqYqy4bOJsLaMNK1qAa' id='SDC9CABFzJ2' alt='' width='800' height='142'></img></div><br/>
+
+<h2 id='SDC9CAlxVyz'>Allowing your lambda to retrieve the Secret</h2>
+
+Once you have your Encryption Key setup along with your Secret in Secrets Manager you’d need to allow your Rule’s Lambda to retrieve the secret. You can do this from IAM.<br/>
+
+<br/>
+
+Look for your Lambda Role, RDK will create one per rule by default, you can use the name of your rule to locate it. In this example the rule name is “QualysTESTRule”<br/>
+
+<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/TeQExWuzs3CDfsvfgE_uJQ?a=8PQP8zaolWU7l6hIsSt6c7ffhVfGOhcRYZPN7NnDgvIa' id='SDC9CA1eIfe' alt='' width='800' height='435'></img></div><br/>
+
+You’d need to attach new permissions to this role, you can create a new Policy or use an In-Line policy. Do so according to your organization’s standards. <br/>
+
+<div data-section-style='5' class="" style=""><ul id='SDC9CAg1LiS'><li id='SDC9CAEAtOh' class='' value='1'>In the Service Field, select “Secrets Manager”
+
+<br/></li><li id='SDC9CAzrWoZ' class=''>In Access Level, select “Read: GetSecretValue”
+
+<br/></li></ul></div><div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/C1ZTta2qjgfTWCffA8AA8A?a=Gxbx9aWDFZDMaj9hW3XzmJZSDMYW7MXqBq79r89CEDoa' id='SDC9CAmBZlP' alt='' width='800' height='559'></img></div>Next you will specify your resource, this is the Secret Manager’s Secret ARN <br/>
+
+<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/0Qy2N8GhTu1JKpLMrSjQTQ?a=dPIafoQ8DV6jC0aB6nn9Rv3lP9UadQTctRgOdIchaSYa' id='SDC9CAPnCHr' alt='' width='800' height='135'></img></div><br/>
+
+You can retrieve your Secret ARN from the Secrets Manager Console:<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/PnE-NOrrrs6lF2nmAL-6TA?a=2PJ9aHTL7a2UvJkfxVToaIewFeB4X1XEVstohgEMsX8a' id='SDC9CAW1sez' alt='' width='800' height='298'></img></div><br/>
+
+If you decide to use a different Secret Name make sure you update line 246 to point to the right Secret.<br/>
+
+<br/>
+
+<h2 id='SDC9CAuMhjy'>Re-evaluating</h2>
+
+After you setup your environment as per the instructions above, you can re-evaluate your rule so that it communicates with Qualys and checks the reporting status of your instances.<br/>
+
+<br/>
+
+To do this, navigate back to the Rule View in AWS Config.<br/>
+
+<br/>
+
+On the top right corner, click on the “Re-evaluate” button to force the rule to run once more.<br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/GZzu3EmqUdfTXSZtKeS4ew?a=3nhN0QlgxjF9P8SeqqhXJ8cwZw7ItdJoImreTgvKJVIa' id='SDC9CAVkRwR' alt='' width='800' height='113'></img></div>After this, the rule will run as per the “Trigger type” specified in the rule settings, the screenshot above shows a periodic schedule of once each hour. You can customize this by editing the parameters.json file in the rule folder before deployment. <br/>
+
+<div data-section-style='11' style='max-width:100%'><img src='https://quip-amazon.com/blob/SDC9AAKVGGZ/ca-4olnFScPz9NvU6oiyAg?a=ZDa30O49WtlbAQBdxEO9UhIvsWBq0uQGzrIvl92UG0Ea' id='SDC9CAPrCpG' alt=''></img></div><br/>
+
+<br/>
+
+<h1 id='SDC9CA5dNLD'>References</h1>
+
+<div data-section-style='5' class="" style=""><ul id='SDC9CABHles'><li id='SDC9CAxK6iH' class='' value='1'>RDK minimum permissions: <a href="https://github.com/awslabs/aws-config-rdk/blob/master/policy/rdk-minimum-permissions.json">https://github.com/awslabs/aws-config-rdk/blob/master/policy/rdk-minimum-permissions.json</a>
+
+<br/></li><li id='SDC9CALRxHE' class=''>RDK: <a href="https://github.com/awslabs/aws-config-rdk">https://github.com/awslabs/aws-config-rdk</a>
+
+<br/></li><li id='SDC9CAk0MUX' class=''>Secrets Manager: <a href="https://aws.amazon.com/secrets-manager/">https://aws.amazon.com/secrets-manager/</a>
+
+<br/></li><li id='SDC9CAujd1v' class=''>KMS: <a href="https://aws.amazon.com/kms/">https://aws.amazon.com/kms/</a>
+
+<br/></li><li id='SDC9CA1KrB7' class=''>AWS Config: <a href="https://aws.amazon.com/config/">https://aws.amazon.com/config/</a>
+
+<br/></li><li id='SDC9CAevmRl' class=''>Qualys API Reference Doc: <a href="https://www.qualys.com/docs/qualys-api-quick-reference.pdf">https://www.qualys.com/docs/qualys-api-quick-reference.pdf</a>
+
+<br/></li><li id='SDC9CAOJrfm' class=''>Boto3 EC2 Documentation: <a href="https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html">https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html</a>
+
+<br/></li><li id='SDC9CAgeB0F' class=''>IAM: <a href="https://aws.amazon.com/iam/">https://aws.amazon.com/iam/</a>
+
+<br/></li></ul></div></body></html>

--- a/python/EC2_Qualys_Reporting_Status/EC2_Qualys_Reporting_Status.py
+++ b/python/EC2_Qualys_Reporting_Status/EC2_Qualys_Reporting_Status.py
@@ -1,0 +1,629 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import json
+import sys
+import datetime
+import boto3
+import botocore
+
+try:
+    import liblogging
+except ImportError:
+    pass
+
+import http.client
+import base64
+from botocore.exceptions import ClientError
+from xml.etree import ElementTree as ET
+from xml.etree import cElementTree as ElementTree
+import ast
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::EC2::Instance'
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (useful for cross-account).
+ASSUME_ROLE_MODE = False
+
+# Other parameters (no change needed)
+CONFIG_ROLE_TIMEOUT_SECONDS = 900
+
+#############
+# Main Code #
+#############
+
+class XmlListConfig(list):
+    def __init__(self, aList):
+        for element in aList:
+            if element:
+                # treat like dict
+                if len(element) == 1 or element[0].tag != element[1].tag:
+                    self.append(XmlDictConfig(element))
+                # treat like list
+                elif element[0].tag == element[1].tag:
+                    self.append(XmlListConfig(element))
+            elif element.text:
+                text = element.text.strip()
+                if text:
+                    self.append(text)
+
+class XmlDictConfig(dict):
+    '''
+    Example usage:
+    >>> root = ElementTree.XML(xml_string)
+    >>> xmldict = XmlDictConfig(root)
+
+    And then use xmldict as a dict.
+    '''
+    def __init__(self, parent_element):
+        if parent_element.items():
+            self.update(dict(parent_element.items()))
+        for element in parent_element:
+            if element:
+                if len(element) == 1 or element[0].tag != element[1].tag:
+                    aDict = XmlDictConfig(element)
+                else:
+                    aDict = {element[0].tag: XmlListConfig(element)}
+                if element.items():
+                    aDict.update(dict(element.items()))
+                self.update({element.tag: aDict})
+            elif element.items():
+                self.update({element.tag: dict(element.items())})
+            else:
+                self.update({element.tag: element.text})
+
+
+def payload_builder(instance):
+    '''
+    Build the XML Payload for Qualys API Search using InstanceId
+    Provide the instance from the ec2 method .describe_instances()['Reservations']['Instances'] response
+    '''
+    instanceId = instance['InstanceId']
+
+    payload = '''<ServiceRequest>
+        <filters>
+            <Criteria field="instanceId" operator="EQUALS">{}</Criteria>
+        </filters>
+    </ServiceRequest>
+    '''.format(instanceId)
+    return payload
+
+
+def base64encoder(string_to_encode):
+    '''
+    This function will encode a string to Base64 for API authentication
+    '''
+    string_to_encode = string_to_encode.encode()
+    string_to_encode = base64.standard_b64encode(string_to_encode)
+    string_to_encode = string_to_encode.decode('UTF-8')
+    return string_to_encode
+
+def qualys_query_instanceId(platform, authorization, payload):
+    '''
+    Function to submit qualys queries looking for assets with an EC2 InstanceId
+
+    qualys_query_instanceId('qg3', authorization, payload)
+
+    '''
+    HOST = platform
+    API_URL = "/qps/rest/2.0/search/am/hostasset"
+    request_body = bytes(payload, encoding = 'utf-8')
+
+    conn = http.client.HTTPSConnection(HOST)
+
+    headers = {
+        'Authorization': "Basic {}".format(authorization),
+        'Accept': "*/*",
+        'Cache-Control': "no-cache",
+        'Host': HOST,
+        'Content-Length': "169",
+        'Content-Type': "application/xml",
+        'Connection': "keep-alive",
+        'cache-control': "no-cache"
+        }
+
+    conn.request("POST", API_URL, body=request_body, headers=headers)
+
+    res = conn.getresponse()
+    data = res.read()
+
+    return data
+
+
+def get_secret(secret_name, region_name):
+
+    ## Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'DecryptionFailureException':
+            # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response['Error']['Code'] == 'InternalServiceErrorException':
+            # An error occurred on the server side.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response['Error']['Code'] == 'InvalidParameterException':
+            # You provided an invalid value for a parameter.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response['Error']['Code'] == 'InvalidRequestException':
+            # You provided a parameter value that is not valid for the current state of the resource.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response['Error']['Code'] == 'ResourceNotFoundException':
+            # We can't find the resource that you asked for.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+    else:
+        # Decrypts secret using the associated KMS CMK.
+        # Depending on whether the secret is a string or binary, one of these fields will be populated.
+        if 'SecretString' in get_secret_value_response:
+            secret = get_secret_value_response['SecretString']
+            return secret
+
+        else:
+            decoded_binary_secret = base64.b64decode(get_secret_value_response['SecretBinary'])
+
+def get_qualys_auth(secret_name, region_name):
+    '''
+    Retrieves Qualys credentials from Secrets Manager, Encodes Said Credentials in Base64
+    Returns the authorization header string for Qualys API Requests.
+    Usage:
+        get_qualys_auth(secret_name, region_name)
+    '''
+    ## Retrieve Qualys Credentials from Secrets Manager
+    qualys_credentials = ast.literal_eval(get_secret(secret_name, region_name))
+    ## Build Authorization for Qualys API Call from Secret Manager Credentials
+    authorization = base64encoder(qualys_credentials['qualys_usr']+":"+qualys_credentials['qualys_pswrd'])
+    return authorization
+
+def fetch_all_items(client, method, response_key, **kwargs):
+    """
+    client: The boto3 client
+    method: The boto3 method to be fetched (e.g. ecs_client.list_clusters)
+    kwargs: The parameter name and value for a given boto3 method (e.g. ecs_client.list_services(cluster=clusterArn))
+    """
+    if kwargs:
+        response = method(**kwargs)
+    else:
+        response = method()
+
+    items = response[response_key]
+    next_token = response.get('NextToken')
+    while next_token:
+        response = client.method(NextToken=next_token)
+        items = items + response[response_key]
+        next_token = response.get('NextToken')
+
+    return items
+
+
+def evaluate_compliance(event, configuration_item, valid_rule_parameters):
+    """Form the evaluation(s) to be return to Config Rules
+
+    Return either:
+    None -- when no result needs to be displayed
+    a string -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    a dictionary -- the evaluation dictionary, usually built by build_evaluation_from_config_item()
+    a list of dictionary -- a list of evaluation dictionary , usually built by build_evaluation()
+
+    Keyword arguments:
+    event -- the event variable given in the lambda handler
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    valid_rule_parameters -- the output of the evaluate_parameters() representing validated parameters of the Config Rule
+
+    Advanced Notes:
+    1 -- if a resource is deleted and generate a configuration change with ResourceDeleted status, the Boilerplate code will put a NOT_APPLICABLE on this resource automatically.
+    2 -- if a None or a list of dictionary is returned, the old evaluation(s) which are not returned in the new evaluation list are returned as NOT_APPLICABLE by the Boilerplate code
+    3 -- if None or an empty string, list or dict is returned, the Boilerplate code will put a "shadow" evaluation to feedback that the evaluation took place properly
+    """
+
+    ## This code would go inside the build_evaluation function
+
+    ## Qualys Secret Details in Secrets Manager
+    secret_name = "QualysCredentials"
+    region_name = "us-east-1"
+
+    ## Qualys API Platform
+    platform = 'qualysapi.qg3.apps.qualys.com'
+    ## Qualys Authorization
+    authorization = get_qualys_auth(secret_name, region_name)
+
+    ## Connect to EC2
+    ec2_service = get_client('ec2', event)
+
+    ## Empty list of evaluations for AWS Config
+    evaluations = []
+
+    ## Strings
+    compliant_str = "Instance has Agent reporting in Qualys"
+    non_compliant_str1 = "Instance does not have Qualys Agent Installed"
+
+
+    ## Retrieve ec2 instance details
+    for Reservations in fetch_all_items(ec2_service, ec2_service.describe_instances, 'Reservations', MaxResults=100):
+        Instances = Reservations['Instances']
+        for instance in Instances:
+            InstanceId = instance['InstanceId']
+            launchTime = str(instance['LaunchTime'])[:10]
+
+            ## Build Qualys API with payload specifying InstanceId
+            payload = payload_builder(instance)
+            ## Get Qualys Results for any hosts that match the Instance ID
+            qualys_results = qualys_query_instanceId(platform, authorization, payload)
+            qualys_xml_response = ElementTree.XML(qualys_results)
+            qualys_dict_response = XmlDictConfig(qualys_xml_response)
+
+            if int(qualys_dict_response['count']) > 0:
+                print("Instance {} has Agent reporting in Qualys".format(InstanceId))
+                annotation = build_annotation(compliant_str)
+                evaluations.append(build_evaluation(InstanceId, 'COMPLIANT', event, annotation=annotation))
+            else:
+                print("No Agent Found for this Instance: ", InstanceId)
+                annotation = build_annotation(non_compliant_str1)
+                evaluations.append(build_evaluation(InstanceId, 'NON_COMPLIANT', event, annotation=annotation))
+
+
+
+    if evaluations:
+        return evaluations
+    else:
+        return 'NOT_APPLICABLE'
+
+
+def evaluate_parameters(rule_parameters):
+    """Evaluate the rule parameters dictionary validity. Raise a ValueError for invalid parameters.
+
+    Return:
+    anything suitable for the evaluate_compliance()
+
+    Keyword arguments:
+    rule_parameters -- the Key/Value dictionary of the Config Rules parameters
+    """
+    valid_rule_parameters = rule_parameters
+    return valid_rule_parameters
+
+####################
+# Helper Functions #
+####################
+
+# Build an error to be displayed in the logs when the parameter is invalid.
+def build_parameters_value_error_response(ex):
+    """Return an error dictionary when the evaluate_parameters() raises a ValueError.
+
+    Keyword arguments:
+    ex -- Exception text
+    """
+    return  build_error_response(internal_error_message="Parameter value is invalid",
+                                 internal_error_details="An ValueError was raised during the validation of the Parameter value",
+                                 customer_error_code="InvalidParameterValueException",
+                                 customer_error_message=str(ex))
+
+# This gets the client after assuming the Config service role
+# either in the same AWS account or cross-account.
+def get_client(service, event, region=None):
+    """Return the service boto client. It should be used instead of directly calling the client.
+
+    Keyword arguments:
+    service -- the service name used for calling the boto.client()
+    event -- the event variable given in the lambda handler
+    region -- the region where the client is called (default: None)
+    """
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service, region)
+    credentials = get_assume_role_credentials(get_execution_role_arn(event), region)
+    return boto3.client(service, aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken'],
+                        region_name=region
+                       )
+
+# This generate an evaluation for config
+def build_evaluation(resource_id, compliance_type, event, resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on scheduled rules.
+
+    Keyword arguments:
+    resource_id -- the unique id of the resource to report
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    event -- the event variable given in the lambda handler
+    resource_type -- the CloudFormation resource type (or AWS::::Account) to report on the rule (default DEFAULT_RESOURCE_TYPE)
+    annotation -- an annotation to be added to the evaluation (default None). It will be truncated to 255 if longer.
+    """
+    eval_cc = {}
+    if annotation:
+        eval_cc['Annotation'] = build_annotation(annotation)
+    eval_cc['ComplianceResourceType'] = resource_type
+    eval_cc['ComplianceResourceId'] = resource_id
+    eval_cc['ComplianceType'] = compliance_type
+    eval_cc['OrderingTimestamp'] = str(json.loads(event['invokingEvent'])['notificationCreationTime'])
+    return eval_cc
+
+def build_evaluation_from_config_item(configuration_item, compliance_type, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on configuration change rules.
+
+    Keyword arguments:
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    annotation -- an annotation to be added to the evaluation (default None). It will be truncated to 255 if longer.
+    """
+    eval_ci = {}
+    if annotation:
+        eval_ci['Annotation'] = build_annotation(annotation)
+    eval_ci['ComplianceResourceType'] = configuration_item['resourceType']
+    eval_ci['ComplianceResourceId'] = configuration_item['resourceId']
+    eval_ci['ComplianceType'] = compliance_type
+    eval_ci['OrderingTimestamp'] = configuration_item['configurationItemCaptureTime']
+    return eval_ci
+
+####################
+# Boilerplate Code #
+####################
+
+# Get execution role for Lambda function
+def get_execution_role_arn(event):
+    role_arn = None
+    if 'ruleParameters' in event:
+        rule_params = json.loads(event['ruleParameters'])
+        role_name = rule_params.get("ExecutionRoleName")
+        if role_name:
+            execution_role_prefix = event["executionRoleArn"].split("/")[0]
+            role_arn = "{}/{}".format(execution_role_prefix, role_name)
+
+    if not role_arn:
+        role_arn = event['executionRoleArn']
+
+    return role_arn
+
+# Build annotation within Service constraints
+def build_annotation(annotation_string):
+    if len(annotation_string) > 256:
+        return annotation_string[:244] + " [truncated]"
+    return annotation_string
+
+# Helper function used to validate input
+def check_defined(reference, reference_name):
+    if not reference:
+        raise Exception('Error: ', reference_name, 'is not defined')
+    return reference
+
+# Check whether the message is OversizedConfigurationItemChangeNotification or not
+def is_oversized_changed_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'OversizedConfigurationItemChangeNotification'
+
+# Check whether the message is a ScheduledNotification or not.
+def is_scheduled_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'ScheduledNotification'
+
+# Get configurationItem using getResourceConfigHistory API
+# in case of OversizedConfigurationItemChangeNotification
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1)
+    configuration_item = result['configurationItems'][0]
+    return convert_api_configuration(configuration_item)
+
+# Convert from the API model to the original invocation model
+def convert_api_configuration(configuration_item):
+    for k, v in configuration_item.items():
+        if isinstance(v, datetime.datetime):
+            configuration_item[k] = str(v)
+    configuration_item['awsAccountId'] = configuration_item['accountId']
+    configuration_item['ARN'] = configuration_item['arn']
+    configuration_item['configurationStateMd5Hash'] = configuration_item['configurationItemMD5Hash']
+    configuration_item['configurationItemVersion'] = configuration_item['version']
+    configuration_item['configuration'] = json.loads(configuration_item['configuration'])
+    if 'relationships' in configuration_item:
+        for i in range(len(configuration_item['relationships'])):
+            configuration_item['relationships'][i]['name'] = configuration_item['relationships'][i]['relationshipName']
+    return configuration_item
+
+# Based on the type of message get the configuration item
+# either from configurationItem in the invoking event
+# or using the getResourceConfigHistiry API in getConfiguration function.
+def get_configuration_item(invoking_event):
+    check_defined(invoking_event, 'invokingEvent')
+    if is_oversized_changed_notification(invoking_event['messageType']):
+        configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
+        return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
+    if is_scheduled_notification(invoking_event['messageType']):
+        return None
+    return check_defined(invoking_event['configurationItem'], 'configurationItem')
+
+# Check whether the resource has been deleted. If it has, then the evaluation is unnecessary.
+def is_applicable(configuration_item, event):
+    try:
+        check_defined(configuration_item, 'configurationItem')
+        check_defined(event, 'event')
+    except:
+        return True
+    status = configuration_item['configurationItemStatus']
+    event_left_scope = event['eventLeftScope']
+    if status == 'ResourceDeleted':
+        print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
+
+    return status in ('OK', 'ResourceDiscovered') and not event_left_scope
+
+
+def get_assume_role_credentials(role_arn, region=None):
+    sts_client = boto3.client('sts', region)
+    try:
+        assume_role_response = sts_client.assume_role(RoleArn=role_arn,
+                                                      RoleSessionName="configLambdaExecution",
+                                                      DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)
+        if 'liblogging' in sys.modules:
+            liblogging.logSession(role_arn, assume_role_response)
+        return assume_role_response['Credentials']
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        print(str(ex))
+        if 'AccessDenied' in ex.response['Error']['Code']:
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response['Error']['Message'] = "InternalError"
+            ex.response['Error']['Code'] = "InternalError"
+        raise ex
+
+# This removes older evaluation (usually useful for periodic rule not reporting on AWS::::Account).
+def clean_up_old_evaluations(latest_evaluations, event):
+
+    cleaned_evaluations = []
+
+    old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+        ConfigRuleName=event['configRuleName'],
+        ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+        Limit=100)
+
+    old_eval_list = []
+
+    while True:
+        for old_result in old_eval['EvaluationResults']:
+            old_eval_list.append(old_result)
+        if 'NextToken' in old_eval:
+            next_token = old_eval['NextToken']
+            old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+                ConfigRuleName=event['configRuleName'],
+                ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+                Limit=100,
+                NextToken=next_token)
+        else:
+            break
+
+    for old_eval in old_eval_list:
+        old_resource_id = old_eval['EvaluationResultIdentifier']['EvaluationResultQualifier']['ResourceId']
+        newer_founded = False
+        for latest_eval in latest_evaluations:
+            if old_resource_id == latest_eval['ComplianceResourceId']:
+                newer_founded = True
+        if not newer_founded:
+            cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
+
+    return cleaned_evaluations + latest_evaluations
+
+def lambda_handler(event, context):
+    if 'liblogging' in sys.modules:
+        liblogging.logEvent(event)
+
+    global AWS_CONFIG_CLIENT
+
+    #print(event)
+    check_defined(event, 'event')
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = {}
+    if 'ruleParameters' in event:
+        rule_parameters = json.loads(event['ruleParameters'])
+
+    try:
+        valid_rule_parameters = evaluate_parameters(rule_parameters)
+    except ValueError as ex:
+        return build_parameters_value_error_response(ex)
+
+    try:
+        AWS_CONFIG_CLIENT = get_client('config', event)
+        if invoking_event['messageType'] in ['ConfigurationItemChangeNotification', 'ScheduledNotification', 'OversizedConfigurationItemChangeNotification']:
+            configuration_item = get_configuration_item(invoking_event)
+            if is_applicable(configuration_item, event):
+                compliance_result = evaluate_compliance(event, configuration_item, valid_rule_parameters)
+            else:
+                compliance_result = "NOT_APPLICABLE"
+        else:
+            return build_internal_error_response('Unexpected message type', str(invoking_event))
+    except botocore.exceptions.ClientError as ex:
+        if is_internal_error(ex):
+            return build_internal_error_response("Unexpected error while completing API request", str(ex))
+        return build_error_response("Customer error while making API request", str(ex), ex.response['Error']['Code'], ex.response['Error']['Message'])
+    except ValueError as ex:
+        return build_internal_error_response(str(ex), str(ex))
+
+    evaluations = []
+    latest_evaluations = []
+
+    if not compliance_result:
+        latest_evaluations.append(build_evaluation(event['accountId'], "NOT_APPLICABLE", event, resource_type='AWS::::Account'))
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, str):
+        if configuration_item:
+            evaluations.append(build_evaluation_from_config_item(configuration_item, compliance_result))
+        else:
+            evaluations.append(build_evaluation(event['accountId'], compliance_result, event, resource_type=DEFAULT_RESOURCE_TYPE))
+    elif isinstance(compliance_result, list):
+        for evaluation in compliance_result:
+            missing_fields = False
+            for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+                if field not in evaluation:
+                    print("Missing " + field + " from custom evaluation.")
+                    missing_fields = True
+
+            if not missing_fields:
+                latest_evaluations.append(evaluation)
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, dict):
+        missing_fields = False
+        for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+            if field not in compliance_result:
+                print("Missing " + field + " from custom evaluation.")
+                missing_fields = True
+        if not missing_fields:
+            evaluations.append(compliance_result)
+    else:
+        evaluations.append(build_evaluation_from_config_item(configuration_item, 'NOT_APPLICABLE'))
+
+    # Put together the request that reports the evaluation status
+    result_token = event['resultToken']
+    test_mode = False
+    if result_token == 'TESTMODE':
+        # Used solely for RDK test to skip actual put_evaluation API call
+        test_mode = True
+
+    # Invoke the Config API to report the result of the evaluation
+    evaluation_copy = []
+    evaluation_copy = evaluations[:]
+    while evaluation_copy:
+        AWS_CONFIG_CLIENT.put_evaluations(Evaluations=evaluation_copy[:100], ResultToken=result_token, TestMode=test_mode)
+        del evaluation_copy[:100]
+
+    # Used solely for RDK test to be able to test Lambda function
+    return evaluations
+
+def is_internal_error(exception):
+    return ((not isinstance(exception, botocore.exceptions.ClientError)) or exception.response['Error']['Code'].startswith('5')
+            or 'InternalError' in exception.response['Error']['Code'] or 'ServiceError' in exception.response['Error']['Code'])
+
+def build_internal_error_response(internal_error_message, internal_error_details=None):
+    return build_error_response(internal_error_message, internal_error_details, 'InternalError', 'InternalError')
+
+def build_error_response(internal_error_message, internal_error_details=None, customer_error_code=None, customer_error_message=None):
+    error_response = {
+        'internalErrorMessage': internal_error_message,
+        'internalErrorDetails': internal_error_details,
+        'customerErrorMessage': customer_error_message,
+        'customerErrorCode': customer_error_code
+    }
+    print(error_response)
+    return error_response

--- a/python/EC2_Qualys_Reporting_Status/EC2_Qualys_Reporting_Status_test.py
+++ b/python/EC2_Qualys_Reporting_Status/EC2_Qualys_Reporting_Status_test.py
@@ -1,0 +1,174 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import sys
+import unittest
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+import botocore
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::::Account'
+
+#############
+# Main Code #
+#############
+
+CONFIG_CLIENT_MOCK = MagicMock()
+STS_CLIENT_MOCK = MagicMock()
+
+class Boto3Mock():
+    @staticmethod
+    def client(client_name, *args, **kwargs):
+        if client_name == 'config':
+            return CONFIG_CLIENT_MOCK
+        if client_name == 'sts':
+            return STS_CLIENT_MOCK
+        raise Exception("Attempting to create an unknown client")
+
+sys.modules['boto3'] = Boto3Mock()
+
+RULE = __import__('EC2_Qualys_Reporting_Status')
+
+class ComplianceTest(unittest.TestCase):
+
+    rule_parameters = '{"SomeParameterKey":"SomeParameterValue","SomeParameterKey2":"SomeParameterValue2"}'
+
+    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"some-arn"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+
+    def setUp(self):
+        pass
+
+    def test_sample(self):
+        self.assertTrue(True)
+
+    #def test_sample_2(self):
+    #    RULE.ASSUME_ROLE_MODE = False
+    #    response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+    #    resp_expected = []
+    #    resp_expected.append(build_expected_response('NOT_APPLICABLE', 'some-resource-id', 'AWS::IAM::Role'))
+    #    assert_successful_evaluation(self, response, resp_expected)
+
+####################
+# Helper Functions #
+####################
+
+def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_lambda_scheduled_event(rule_parameters=None):
+    invoking_event = '{"messageType":"ScheduledNotification","notificationCreationTime":"2017-12-23T22:11:18.158Z"}'
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_expected_response(compliance_type, compliance_resource_id, compliance_resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    if not annotation:
+        return {
+            'ComplianceType': compliance_type,
+            'ComplianceResourceId': compliance_resource_id,
+            'ComplianceResourceType': compliance_resource_type
+            }
+    return {
+        'ComplianceType': compliance_type,
+        'ComplianceResourceId': compliance_resource_id,
+        'ComplianceResourceType': compliance_resource_type,
+        'Annotation': annotation
+        }
+
+def assert_successful_evaluation(test_class, response, resp_expected, evaluations_count=1):
+    if isinstance(response, dict):
+        test_class.assertEquals(resp_expected['ComplianceResourceType'], response['ComplianceResourceType'])
+        test_class.assertEquals(resp_expected['ComplianceResourceId'], response['ComplianceResourceId'])
+        test_class.assertEquals(resp_expected['ComplianceType'], response['ComplianceType'])
+        test_class.assertTrue(response['OrderingTimestamp'])
+        if 'Annotation' in resp_expected or 'Annotation' in response:
+            test_class.assertEquals(resp_expected['Annotation'], response['Annotation'])
+    elif isinstance(response, list):
+        test_class.assertEquals(evaluations_count, len(response))
+        for i, response_expected in enumerate(resp_expected):
+            test_class.assertEquals(response_expected['ComplianceResourceType'], response[i]['ComplianceResourceType'])
+            test_class.assertEquals(response_expected['ComplianceResourceId'], response[i]['ComplianceResourceId'])
+            test_class.assertEquals(response_expected['ComplianceType'], response[i]['ComplianceType'])
+            test_class.assertTrue(response[i]['OrderingTimestamp'])
+            if 'Annotation' in response_expected or 'Annotation' in response[i]:
+                test_class.assertEquals(response_expected['Annotation'], response[i]['Annotation'])
+
+def assert_customer_error_response(test_class, response, customer_error_code=None, customer_error_message=None):
+    if customer_error_code:
+        test_class.assertEqual(customer_error_code, response['customerErrorCode'])
+    if customer_error_message:
+        test_class.assertEqual(customer_error_message, response['customerErrorMessage'])
+    test_class.assertTrue(response['customerErrorCode'])
+    test_class.assertTrue(response['customerErrorMessage'])
+    if "internalErrorMessage" in response:
+        test_class.assertTrue(response['internalErrorMessage'])
+    if "internalErrorDetails" in response:
+        test_class.assertTrue(response['internalErrorDetails'])
+
+def sts_mock():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string"}}
+    STS_CLIENT_MOCK.reset_mock(return_value=True)
+    STS_CLIENT_MOCK.assume_role = MagicMock(return_value=assume_role_response)
+
+##################
+# Common Testing #
+##################
+
+class TestStsErrors(unittest.TestCase):
+
+    def test_sts_unknown_error(self):
+        RULE.ASSUME_ROLE_MODE = True
+        RULE.evaluate_parameters = MagicMock(return_value=True)
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'unknown-code', 'Message': 'unknown-message'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'InternalError', 'InternalError')
+
+    def test_sts_access_denied(self):
+        RULE.ASSUME_ROLE_MODE = True
+        RULE.evaluate_parameters = MagicMock(return_value=True)
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'AccessDenied', 'AWS Config does not have permission to assume the IAM role.')

--- a/python/EC2_Qualys_Reporting_Status/parameters.json
+++ b/python/EC2_Qualys_Reporting_Status/parameters.json
@@ -1,0 +1,12 @@
+{
+  "Version": "1.0",
+  "Parameters": {
+    "RuleName": "EC2_Qualys_Reporting_Status",
+    "SourceRuntime": "python3.7",
+    "CodeKey": "EC2_Qualys_Reporting_Status.zip",
+    "InputParameters": "{}",
+    "OptionalParameters": "{}",
+    "SourcePeriodic": "TwentyFour_Hours"
+  },
+  "Tags": "[]"
+}


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

Description of changes: 

This config rule will check for Qualys Agent Reporting Status of an EC2 Instance.
The rule leverages multiple services such as Secret Manager and KMS to store Qualys API Credentials. 
A detailed walk-through has been added inside the folder to ease deployment. 

