### PR TITLE
updated logic and tests for sagemaker

### DIFF
--- a/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED.py
+++ b/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED.py
@@ -65,6 +65,7 @@ import datetime
 import re
 import boto3
 import botocore
+from functools import reduce
 
 try:
     import liblogging
@@ -107,7 +108,7 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
         elif not valid_rule_parameters:
             evaluations.append(build_evaluation(notebook_instance['NotebookInstanceName'], 'COMPLIANT', event))
         #SCENARIO 5: KMS key specified for Amazon SageMaker Notebook Instance matches keyArn in rule parameter.
-        elif notebook_instance_description['KmsKeyId'] in valid_rule_parameters:
+        elif reduce((lambda x, y: x or y), [notebook_instance_description['KmsKeyId'] in keyId for keyId in valid_rule_parameters]):
             evaluations.append(build_evaluation(notebook_instance['NotebookInstanceName'], 'COMPLIANT', event))
         #SCENARIO 4: KMS key specified for Amazon SageMaker Notebook Instance does not match keyArn in rule parameter.
         else:

--- a/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED.py
+++ b/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED.py
@@ -63,9 +63,9 @@ import json
 import sys
 import datetime
 import re
+from functools import reduce
 import boto3
 import botocore
-from functools import reduce
 
 try:
     import liblogging

--- a/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED_test.py
+++ b/python/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED/SAGEMAKER_NOTEBOOK_KMS_CONFIGURED_test.py
@@ -53,9 +53,9 @@ class ComplianceTest(unittest.TestCase):
     no_notebook_instances_list = {"NotebookInstances": []}
     notebook_instances_list_mixed = [{'NotebookInstances': [{'NotebookInstanceName': 'trial12'}, {'NotebookInstanceName': 'trial123'}, {'NotebookInstanceName': 'trial1234'}]}]
 
-    described_notebook_instances = [{'NotebookInstanceName': 'trial12', 'KmsKeyId': 'arn:aws:kms:us-east-1:123456789012:key/7af97db7-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial123', 'KmsKeyId': 'arn:aws:kms:us-east-1:123456789012:key/7af97db7-f6a3-4d0a-87b9-a2737b54856d'}]
+    described_notebook_instances = [{'NotebookInstanceName': 'trial12', 'KmsKeyId': '7af97db7-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial123', 'KmsKeyId': '7af97db7-f6a3-4d0a-87b9-a2737b54856d'}]
     described_notebooks_no_key = [{'NotebookInstanceName': 'trial12'}, {'NotebookInstanceName': 'trial123'}]
-    described_notebooks_mixed = [{'NotebookInstanceName': 'trial12', 'KmsKeyId': 'arn:aws:kms:us-east-1:123456789012:key/7af97db7-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial123', 'KmsKeyId': 'arn:aws:kms:us-east-1:123456789012:key/7af97db6-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial1234'}]
+    described_notebooks_mixed = [{'NotebookInstanceName': 'trial12', 'KmsKeyId': '7af97db7-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial123', 'KmsKeyId': '7af97db6-f6a3-4d0a-87b9-a2737b54856d'}, {'NotebookInstanceName': 'trial1234'}]
 
     rule_params_mismatched_key = '{"keyArns":"arn:aws:kms:us-east-1:123456789012:key/7af97db6-f6a3-4d0a-87b9-a2737b54856d, arn:aws:kms:us-east-1:123456789012:key/7af97db6-f6a3-4d0a-87b9-a2737b54856e"}'
     rule_params_matched_key = '{"keyArns":"arn:aws:kms:us-east-1:123456789012:key/7af97db7-f6a3-4d0a-87b9-a2737b54856d, arn:aws:kms:us-east-1:123456789012:key/7af97db7-f6a3-4d0a-87b9-a2737b54856e"}'


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Description of changes:*

The API response from the SageMaker client for `describe_notebook_instance` is below. The value at `KmsKeyId` is just the Key Id, not the ARN as is expected in the config rule code. Due to this difference, compliant notebook instances are being flagged as non compliant. 

The updated logic checks to make sure the `KmsKeyId` string exists in at least one of the supplied ARNs and if it does, the instance is compliant. The test mocks were also updated to reflect the API response.

```{
    "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:xxx:notebook-instance/compliant-sagemaker",
    "NotebookInstanceName": "compliant-sagemaker",
    "NotebookInstanceStatus": "InService",
    "Url": "compliant-sagemaker.notebook.us-east-1.sagemaker.aws",
    "InstanceType": "ml.t2.medium",
    "SubnetId": "subnet-xxx",
    "SecurityGroups": [
        "sg-xxxx"
    ],
    "RoleArn": "arn:aws:iam::xxx:role/sagemaker-role",
    "KmsKeyId": "3xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxe",
    "NetworkInterfaceId": "eni-xxx",
    "LastModifiedTime": 1580509333.953,
    "CreationTime": 1580509123.302,
    "DirectInternetAccess": "Disabled",
    "VolumeSizeInGB": 5,
    "RootAccess": "Enabled"
}```
