### PR TITLE
EC2_TAG_VOLUMES

### DIFF
--- a/python-rdklib/EC2_TAG_VOLUMES/EC2_TAG_VOLUMES.py
+++ b/python-rdklib/EC2_TAG_VOLUMES/EC2_TAG_VOLUMES.py
@@ -1,0 +1,144 @@
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+"""
+#####################################
+##           Gherkin               ##
+#####################################
+
+Rule Name:
+  EC2_TAG_VOLUMES
+
+Description:
+  Checks whether the Amazon Elastic Block Store (EBS) volume includes the Tags from the Amazon Elastic Compute Cloud (Amazon EC2) instance, it's attached to.  The rule is NON_COMPLIANT if the volume is attached to an instance and doesn't include the instance tags. # noqa: E501
+
+Rationale:
+  Ensures that Amazon Elastic Block Store (EBS) volumes are always tagged properly, as the instance it is attached to.
+
+Trigger:
+  Configuration Change on AWS::EC2::Volume
+
+Reports on:
+  AWS::IAM::Volume
+
+Rule Parameters:
+  ExecutionRoleName
+    (Required) AWS Identity and Access Management (IAM) role that will be assumed by the Custom Config Rule Lambda.
+
+Scenarios:
+  Scenario 1:
+    Given: The EBS Volume Tags includes all of the Tags associated to the EC2 instance that it is attached to.
+     Then: return COMPLIANT
+  Scenario 2:
+    Given: The EBS Volume Tags does not include all of the Tags associated to the EC2 instance that it is attached to.
+     Then: return NON_COMPLIANT
+  Scenario 3:
+    Given: The EBS Volume is not attached to an EC2 instance.
+     Then: return NOT_APPLICABLE
+"""
+
+from rdklib import ComplianceType, ConfigRule, Evaluation, Evaluator
+
+APPLICABLE_RESOURCES = ["AWS::EC2::Volume", "AWS::EC2::Instance"]
+DEFAULT_RESOURCE_TYPE = "AWS::EC2::Volume"
+
+
+class EC2_TAG_VOLUMES(ConfigRule):
+    def evaluate_change(self, event, client_factory, configuration_item, valid_rule_parameters):
+        ec2_client = client_factory.build_client("ec2")
+        resource_type = configuration_item.get("resourceType")
+        if resource_type == "AWS::EC2::Volume":
+            volume_id = configuration_item.get("resourceId")
+            if configuration_item.get("configuration").get("attachments"):
+                instance_id = configuration_item.get("configuration").get("attachments")[0].get("instanceId")
+            # Scenario:3 EBS Volume not attached to an EC2 instance.
+            if not configuration_item.get("configuration").get("attachments"):
+                return [Evaluation(ComplianceType.NOT_APPLICABLE)]
+            volume_tags = configuration_item.get("configuration").get("tags")
+            instance_tags = get_instance_tags(ec2_client, instance_id)
+            tags_to_apply = compare_instance_tags_to_volume_tags(instance_tags, volume_tags)
+            # Scenario:1 EBS Volume Tags includes same tags as EC2 Instance its attached to.
+            if not tags_to_apply:
+                return [Evaluation(ComplianceType.COMPLIANT)]
+            # Scenario:2 EBS Volume Tags does not include the same tags as EC2 Instance its attached to.
+            annotation = "EBS Volume needs to have EC2 Instance Tags applied."
+            return [Evaluation(ComplianceType.NON_COMPLIANT, annotation=annotation)]
+
+        if resource_type == "AWS::EC2::Instance":
+            instance_id = configuration_item.get("resourceId")
+            instance_tags = configuration_item.get("configuration").get("tags")
+            block_device_mappings = configuration_item.get("configuration").get("blockDeviceMappings")
+            all_volumes = get_volumes_attached_to_instance(block_device_mappings)
+            evaluations = list()
+            for volume in all_volumes:
+                volume_id = volume
+                volume_tags = get_volume_tags(ec2_client, volume_id)
+                tags_to_apply = compare_instance_tags_to_volume_tags(instance_tags, volume_tags)
+                # Scenario:1 EBS Volume Tags includes same tags as EC2 Instance its attached to.
+                if not tags_to_apply:
+                    evaluations.append(Evaluation(ComplianceType.COMPLIANT, volume_id, DEFAULT_RESOURCE_TYPE))
+                # Scenario:2 EBS Volume Tags does not include the same tags as EC2 Instance its attached to.
+                if tags_to_apply:
+                    annotation = "EBS Volume needs to have EC2 Instance Tags applied."
+                    evaluations.append(
+                        Evaluation(ComplianceType.NON_COMPLIANT, volume_id, DEFAULT_RESOURCE_TYPE, annotation)
+                    )
+            return evaluations
+
+    def evaluate_parameters(self, rule_parameters):
+        valid_rule_parameters = rule_parameters
+        return valid_rule_parameters
+
+
+def get_volume_tags(ec2_client, volume_id):
+    response = ec2_client.describe_tags(Filters=[{"Name": "resource-id", "Values": [volume_id]}])
+    volume_tags = list()
+    for tag in response.get("Tags"):
+        # Skip Tag Keys starting with "aws:", as they are reserved for internal AWS use.
+        if tag["Key"].startswith("aws:"):
+            continue
+        tag_value = {"Key": tag["Key"], "Value": tag["Value"]}
+        volume_tags.append(tag_value)
+    return volume_tags
+
+
+def get_instance_tags(ec2_client, instance_id):
+    response = ec2_client.describe_tags(Filters=[{"Name": "resource-id", "Values": [instance_id]}])
+    instance_tags = list()
+    for tag in response.get("Tags"):
+        # Skip Tag Keys starting with "aws:", as they are reserved for internal AWS use.
+        if tag["Key"].startswith("aws:"):
+            continue
+        tag_value = {"Key": tag["Key"], "Value": tag["Value"]}
+        instance_tags.append(tag_value)
+    return instance_tags
+
+
+def compare_instance_tags_to_volume_tags(instance_tags, volume_tags):
+    tags_to_apply = [i for i in instance_tags if i not in volume_tags]
+    return tags_to_apply
+
+
+def get_volumes_attached_to_instance(block_device_mappings):
+    volume_ids = list()
+    for volume in block_device_mappings:
+        volume_id = volume.get("ebs").get("volumeId")
+        volume_ids.append(volume_id)
+
+    return volume_ids
+
+
+################################
+# DO NOT MODIFY ANYTHING BELOW #
+################################
+def lambda_handler(event, context):
+    my_rule = EC2_TAG_VOLUMES()
+    evaluator = Evaluator(my_rule, APPLICABLE_RESOURCES)
+    return evaluator.handle(event, context)

--- a/python-rdklib/EC2_TAG_VOLUMES/EC2_TAG_VOLUMES_test.py
+++ b/python-rdklib/EC2_TAG_VOLUMES/EC2_TAG_VOLUMES_test.py
@@ -1,0 +1,66 @@
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import unittest
+
+import rdklib
+import rdklibtest
+from botocore.exceptions import ClientError
+from mock import MagicMock, patch
+from rdklib import ComplianceType, Evaluation
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+RESOURCE_TYPE = "AWS::EC2::Volume"
+
+#############
+# Main Code #
+#############
+
+MODULE = __import__("EC2_TAG_VOLUMES")
+RULE = MODULE.EC2_TAG_VOLUMES()
+
+CLIENT_FACTORY = MagicMock()
+
+# example for mocking S3 API calls
+EC2_CLIENT_MOCK = MagicMock()
+
+
+def mock_get_client(client_name, *args, **kwargs):
+    if client_name == "ec2":
+        return EC2_CLIENT_MOCK
+    raise Exception("Attempting to create an unknown client")
+
+
+@patch.object(CLIENT_FACTORY, "build_client", MagicMock(side_effect=mock_get_client))
+class ComplianceTest(unittest.TestCase):
+
+    rule_parameters = '{"SomeParameterKey":"SomeParameterValue","SomeParameterKey2":"SomeParameterValue2"}'
+
+    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"some-arn"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+
+    def setUp(self):
+        pass
+
+    def test_sample(self):
+        self.assertTrue(True)
+
+
+def test_sample_2(self):
+    response = MODULE.lambda_handler(
+        rdklib.build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {}
+    )
+    resp_expected = []
+    resp_expected.append(rdklib.build_expected_response("NOT_APPLICABLE", "some-resource-id", "AWS::IAM::Role"))
+    rdklib.assert_successful_evaluation(self, response, resp_expected)

--- a/python-rdklib/EC2_TAG_VOLUMES/ec2_tag_volumes_ssm_document_executeScript.yaml
+++ b/python-rdklib/EC2_TAG_VOLUMES/ec2_tag_volumes_ssm_document_executeScript.yaml
@@ -1,0 +1,87 @@
+description: 'Tags Volumes to ensure it includes the same Tags as those of the EC2 Instance its attached to.'
+schemaVersion: '0.3'
+assumeRole: '{{ AutomationAssumeRole }}'
+parameters:
+  Volume:
+    type: String
+    description: (Required) The EBS Volume ID that will have tags applied.
+  AutomationAssumeRole:
+    type: String
+    default: 'arn:aws:iam::{{global:ACCOUNT_ID}}:role/Rdk-SSMAutomation-Admin-Role'
+    description: >-
+      (Optional) The Amazon Resource Name (ARN) of the role that allows SSM
+      Automation to perform the actions on your behalf.
+mainSteps:
+  - name: tag_volumes
+    action: 'aws:executeScript'
+    inputs:
+      Runtime: python3.6
+      Handler: tag_volumes_handler
+      Script: |
+        import sys
+
+        import boto3
+
+
+        def tag_volumes_handler(events, context):
+            ec2_client = boto3.client("ec2")
+            volume_id = events.get("Volume")
+            instance_id = get_instance_attached_to_volume(ec2_client, volume_id)
+            if not instance_id:
+                return "Exiting! EBS Volume not attached to an EC2 instance."
+            volume_tags = get_volume_tags(ec2_client, volume_id)
+            instance_tags = get_instance_tags(ec2_client, instance_id)
+            tags_to_apply = compare_instance_tags_to_volume_tags(instance_tags, volume_tags)
+            results = tag_volume(ec2_client, volume_id, tags_to_apply)
+            if results:
+                return "Tags Applied!"
+            if not results:
+                return "No Tags to Apply!"
+
+
+        def get_instance_attached_to_volume(ec2_client, volume_id):
+            response = ec2_client.describe_volumes(VolumeIds=[volume_id])
+            if response.get("Volumes")[0].get("Attachments"):
+                instance_id = response.get("Volumes")[0].get("Attachments")[0].get("InstanceId")
+            if not response.get("Volumes")[0].get("Attachments"):
+                instance_id = False
+            return instance_id
+
+
+        def get_volume_tags(ec2_client, volume_id):
+            response = ec2_client.describe_tags(Filters=[{"Name": "resource-id", "Values": [volume_id]}])
+            volume_tags = list()
+            for tag in response.get("Tags"):
+                # Skip Tag Keys starting with "aws:", as they are reserved for internal AWS use.
+                if tag["Key"].startswith("aws:"):
+                    continue
+                tag_value = {"Key": tag["Key"], "Value": tag["Value"]}
+                volume_tags.append(tag_value)
+            return volume_tags
+
+
+        def get_instance_tags(ec2_client, instance_id):
+            response = ec2_client.describe_tags(Filters=[{"Name": "resource-id", "Values": [instance_id]}])
+            instance_tags = list()
+            for tag in response.get("Tags"):
+                # Skip Tag Keys starting with "aws:", as they are reserved for internal AWS use.
+                if tag["Key"].startswith("aws:"):
+                    continue
+                tag_value = {"Key": tag["Key"], "Value": tag["Value"]}
+                instance_tags.append(tag_value)
+            return instance_tags
+
+
+        def compare_instance_tags_to_volume_tags(instance_tags, volume_tags):
+            tags_to_apply = [i for i in instance_tags if i not in volume_tags]
+            return tags_to_apply
+
+
+        def tag_volume(ec2_client, volume_id, tags_to_apply):
+            if tags_to_apply:
+                ec2_client.create_tags(Resources=[volume_id], Tags=tags_to_apply)
+                return True
+            if not tags_to_apply:
+                return False
+      InputPayload:
+        Volume: '{{Volume}}'

--- a/python-rdklib/EC2_TAG_VOLUMES/parameters.json
+++ b/python-rdklib/EC2_TAG_VOLUMES/parameters.json
@@ -1,0 +1,34 @@
+{
+  "Version": "1.0",
+  "Parameters": {
+    "RuleName": "EC2_TAG_VOLUMES",
+    "SourceRuntime": "python3.6-lib",
+    "CodeKey": "EC2_TAG_VOLUMES.zip",
+    "InputParameters": "{\"ExecutionRoleName\": \"Rdk-XA-Role\"}",
+    "OptionalParameters": "{}",
+    "SourceEvents": "AWS::EC2::Volume",
+    "Remediation": {
+      "ConfigRuleName": "EC2_TAG_VOLUMES",
+      "Parameters": {
+        "AutomationAssumeRole": {
+          "StaticValue": {
+            "Values": [
+              {
+                "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/Rdk-SSMAutomation-Admin-Role"
+              }
+            ]
+          }
+        },
+        "Volume": {
+          "ResourceValue": {
+            "Value": "RESOURCE_ID"
+          }
+        }
+      },
+      "ResourceType": "AWS::EC2::Volume",
+      "TargetId": "Ec2TagVolumes-Script",
+      "TargetType": "SSM_DOCUMENT"
+    }
+  },
+  "Tags": "[]"
+}


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*

**Config Rule:** Checks whether the Amazon Elastic Block Store (EBS) volume includes the Tags from the Amazon Elastic Compute Cloud (Amazon EC2) instance, it's attached to.  The rule is NON_COMPLIANT if the volume is attached to an instance and doesn't include the instance tags. 

**SSM Automation Document:** Tags Volumes to ensure it includes the same Tags as those of the EC2 Instance its attached to.
