### PR TITLE
Update guava version to 24.1.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>[24.1.1,)</version>
     </dependency>
     
   </dependencies>


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*

Upgrade com.google.guava:guava to version 24.1.1 or later. Version must be greater than or equal to 24.1.1

<dependency>
  <groupId>com.google.guava</groupId>
  <artifactId>guava</artifactId>
  <version>[24.1.1,)</version>
</dependency>