### PR TITLE
Updated config rule naming for encryption

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3-with-Remediation.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3-with-Remediation.yaml
@@ -123,6 +123,7 @@ Resources:
       Source:
         Owner: AWS
         SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+
   S3BucketServerSideEncryptionEnabledRemediation:
     DependsOn: S3BucketServerSideEncryptionEnabled
     Type: 'AWS::Config::RemediationConfiguration'

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3.yaml
@@ -55,10 +55,10 @@ Resources:
       Source: 
         Owner: AWS
         SourceIdentifier: S3_BUCKET_SSL_REQUESTS_ONLY
-  ServerSideReplicationEnabled: 
+  S3BucketServerSideEncryptionEnabled:
     Type: "AWS::Config::ConfigRule"
     Properties: 
-      ConfigRuleName: ServerSideReplicationEnabled
+      ConfigRuleName: S3BucketServerSideEncryptionEnabled
       Description: "Checks that your Amazon S3 bucket either has S3 default encryption enabled or that the S3 bucket policy explicitly denies put-object requests without server side encryption."
       Scope: 
         ComplianceResourceTypes: 


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

The rule `ServerSideReplicationEnabled` appeared to be mis-named both in purpose and convention, so I changed it to match the rule-name from other policies.