### PR TITLE
Fix typo ServerSideReplicationEnabled -> ServerSideEncryptionEnabled

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Amazon-S3.yaml
@@ -55,10 +55,10 @@ Resources:
       Source: 
         Owner: AWS
         SourceIdentifier: S3_BUCKET_SSL_REQUESTS_ONLY
-  ServerSideReplicationEnabled: 
+  ServerSideEncryptionEnabled: 
     Type: "AWS::Config::ConfigRule"
     Properties: 
-      ConfigRuleName: ServerSideReplicationEnabled
+      ConfigRuleName: ServerSideEncryptionEnabled
       Description: "Checks that your Amazon S3 bucket either has S3 default encryption enabled or that the S3 bucket policy explicitly denies put-object requests without server side encryption."
       Scope: 
         ComplianceResourceTypes: 


### PR DESCRIPTION
For #347

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
#347

*Description of changes:*
Fix typo on lines 58 and 61 s/ServerSideReplicationEnabled/ServerSideEncryptionEnabled