### PR TITLE
Use gateway id instead of name in API_GW_RESTRICTED rules

### DIFF
--- a/python/API_GW_PRIVATE_RESTRICTED/API_GW_PRIVATE_RESTRICTED.py
+++ b/python/API_GW_PRIVATE_RESTRICTED/API_GW_PRIVATE_RESTRICTED.py
@@ -141,12 +141,12 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
 
         #Scenario 1:
         if 'PRIVATE' not in gateway['endpointConfiguration']['types']:
-            evaluations.append(build_evaluation(gateway['name'], 'NOT_APPLICABLE', event))
+            evaluations.append(build_evaluation(gateway['id'], 'NOT_APPLICABLE', event))
             continue
 
         #Scenario 2:
         if 'policy' not in gateway:
-            evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='No resource policy is attached.'))
+            evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='No resource policy is attached.'))
             continue
 
         policy = json.loads(gateway['policy'].replace('\\', ''))
@@ -159,31 +159,31 @@ def evaluate_compliance(event, configuration_item, valid_rule_parameters):
                 policy_has_allow_statement = True
 
                 if not allow_statement_has_options(statement):
-                    evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='The Allow statement does not have VPC nor a VPCe.'))
+                    evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='The Allow statement does not have VPC nor a VPCe.'))
                     is_gateway_compliant = False
                     break
 
                 if allow_statement_has_attrib(statement, 'aws:sourceVpc'):
                     vpc_list = statement['Condition']['StringEquals']['aws:sourceVpc']
                     if not is_resource_in_same_account(vpc_list, 'VpcId', all_vpc_in_account['Vpcs']):
-                        evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='The VPCs are not in the same account than this API Gateway.'))
+                        evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='The VPCs are not in the same account than this API Gateway.'))
                         is_gateway_compliant = False
                         break
 
                 if allow_statement_has_attrib(statement, 'aws:sourceVpce'):
                     vpce_list = statement['Condition']['StringEquals']['aws:sourceVpce']
                     if not is_resource_in_same_account(vpce_list, 'VpcEndpointId', all_vpce_in_account):
-                        evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='The VPCEs are not in the same account than this API Gateway.'))
+                        evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='The VPCEs are not in the same account than this API Gateway.'))
                         is_gateway_compliant = False
                         break
 
         if not policy_has_allow_statement:
-            evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='This API has no resource policy with an Allow statement.'))
+            evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='This API has no resource policy with an Allow statement.'))
             is_gateway_compliant = False
             continue
 
         if is_gateway_compliant:
-            evaluations.append(build_evaluation(gateway['name'], 'COMPLIANT', event))
+            evaluations.append(build_evaluation(gateway['id'], 'COMPLIANT', event))
 
     return evaluations
 

--- a/python/API_GW_RESTRICTED_IP/API_GW_RESTRICTED_IP.py
+++ b/python/API_GW_RESTRICTED_IP/API_GW_RESTRICTED_IP.py
@@ -136,21 +136,21 @@ def evaluate_compliance(event, configuration_item, rule_parameters):
     for gateway in gateways_list:
 
         if gateway['endpointConfiguration']['types'] == ['PRIVATE']:
-            evaluations.append(build_evaluation(gateway['name'], 'NOT_APPLICABLE', event))
+            evaluations.append(build_evaluation(gateway['id'], 'NOT_APPLICABLE', event))
             continue
         
         
         if 'policy' not in gateway:
-            evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='No resource policy is attached.'))
+            evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='No resource policy is attached.'))
             continue
 
         policy = json.loads(gateway['policy'].replace('\\',''))
         
         if is_policy_allows_more_than_whitelist(policy, rule_parameters):
-            evaluations.append(build_evaluation(gateway['name'], 'NON_COMPLIANT', event, annotation='The attached policy allows more than the whitelist.'))
+            evaluations.append(build_evaluation(gateway['id'], 'NON_COMPLIANT', event, annotation='The attached policy allows more than the whitelist.'))
             continue
         
-        evaluations.append(build_evaluation(gateway['name'], 'COMPLIANT', event))
+        evaluations.append(build_evaluation(gateway['id'], 'COMPLIANT', event))
 
     return evaluations
 


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
#342 

*Description of changes:*
Use gateway id instead of name in API_GW_RESTRICTED rules