### PR TITLE
Adding test for VPCe policy tests to ensure non-default policy implemented

### DIFF
--- a/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY.py
+++ b/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY.py
@@ -1,0 +1,434 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+'''
+Description
+   Check whether VPC Endpoint is using a default open policy
+Trigger
+   Periodic (because VPC Configuration Item does not record Endpoint status)
+Reports on:
+   AWS::EC2::VPC
+Rule Parameters:
+   None
+Scenarios:
+  Scenario 1:
+  Given: No VPC is present while using the describe_vpcs() API call
+   Then: Return NOT_APPLICABLE
+  Scenario 2:
+  Given: At least one VPC is present
+    And: No interface or gateway endpoint is present on DescribeVpcEndpoints API
+   Then: Return NOT_APPLICABLE on this VPC
+  Scenario 3:
+  Given: At least one VPC is present
+    And: An interface or gateway endpoint is present on DescribeVpcEndpoints API
+    And: The policy attached to the endpoint is the default open policy
+   Then: Return NON_COMPLIANT on this VPC
+  Scenario 4:
+  Given: At least one VPC is present
+    And: An interface or gateway endpoint is present on DescribeVpcEndpoints API
+    And: The policy attached to the endpoint does not have the default allow */* policy attached, without conditions.
+   Then: Return COMPLIANT on this VPC
+'''
+import json
+import sys
+import datetime
+import boto3
+import botocore
+
+
+try:
+    import liblogging
+except ImportError:
+    pass
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::EC2::VPC'
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (useful for cross-account).
+ASSUME_ROLE_MODE = False
+
+# Other parameters (no change needed)
+CONFIG_ROLE_TIMEOUT_SECONDS = 900
+
+#############
+# Main Code #
+#############
+
+def get_vpcendpoints(vpc_id, event):
+    # Get a list of the VPC Endpoints in a VPC and evaluate each for compliance
+    compliance_results = {}
+    ec2_client = get_client('ec2', event)
+    iam_client = get_client('iam', event)
+    compliance = 'NON_COMPLIANT'
+    annotate = 'There are no VPC interface endpoints present in '+ vpc_id+'.'
+    response = ec2_client.describe_vpc_endpoints(Filters=[
+                {
+                    'Name':'vpc-id',
+                    'Values':[vpc_id]
+                },
+                {
+                    'Name':'vpc-endpoint-type',
+                    'Values':['Interface','Gateway']
+                }])
+    if response['VpcEndpoints'] != []:
+        for vpce in response['VpcEndpoints']:
+            policy_document = vpce['PolicyDocument']
+            annotate = 'The interface VPC endpoint ('+vpce['VpcEndpointId']+') is using the default open policy in VPC '+vpc_id+'.'
+            if not is_open(iam_client,policy_document,get_service_name(vpce['ServiceName'])):
+                annotate = None
+                compliance = 'COMPLIANT'
+    compliance_results['%s' %(vpc_id)] = [annotate, compliance]
+    return compliance_results
+
+def is_open(client,resource_policy,service_name):
+    # Uses policy evaluation to review if a bad actor can execute actions on objects outside the account that might consitute a data exfil event
+    service_actions = {
+        "s3" : ['s3:PutObject','s3:PutObjectVersion','s3:GetObject','s3:GetObjectVersion','s3:GetObjectTorrent','s3:GetObjectVersionTorrent','s3:PutObjectTagging','s3:ReplicateObject'],
+        "lambda" : ['lambda:CreateFunction','lambda:PublishVersion','lambda:PublishLayerVersion','lambda:UpdateFunctionCode' ]
+    }
+
+    if service_name not in service_actions:
+        return is_open_basic(resource_policy)
+
+    service_arns = {
+        "s3" : ['arn:aws:s3:::Bucket/Key'],
+        "lambda" : ['arn:aws:lambda:::function:FunctionName']
+    }
+    principal_policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": service_actions[service_name],
+                "Resource": "*"
+            } 
+        ]}
+        )
+    response = client.simulate_custom_policy(
+        PolicyInputList=[principal_policy],
+        ActionNames=service_actions[service_name],
+        ResourceArns=service_arns[service_name],
+        ResourcePolicy=resource_policy,
+        ResourceOwner='arn:aws:iam::112233445566:root'
+    )
+    for evaluationResult in response['EvaluationResults']:
+        if evaluationResult['EvalDecision'] == 'allowed':
+            return True
+    return False
+
+def get_service_name(uri):
+    return uri.rsplit('.', 1)[-1]
+
+def is_open_basic(policy_document):
+    # Tests to find a default Allow rule scoping Action:* and Resource:* with no Conditional statements.
+    document = json.loads(policy_document)
+    for statement in document['Statement']:
+        if statement['Effect'] != "Allow":
+            break
+        if statement['Action'] != "*":
+            break
+        if statement['Resource'] != "*":
+            break
+        if "Condition" in statement:
+            break
+        return True
+    return False
+
+# Main entry function
+def evaluate_compliance(event, configuration_item, valid_rule_parameters):
+    evaluations = []
+    ec2_client = get_client('ec2', event)
+    vpc_response = ec2_client.describe_vpcs()
+    if not vpc_response['Vpcs']:
+        evaluations.append(build_evaluation(event['accountId'], 'NOT_APPLICABLE', event))
+        return evaluations
+    for vpc in vpc_response['Vpcs']:
+        evaluation_payload = get_vpcendpoints(vpc['VpcId'], event)
+        evaluations.append(build_evaluation(vpc['VpcId'], evaluation_payload[vpc['VpcId']][1], event, annotation=evaluation_payload[vpc['VpcId']][0]))
+    return evaluations
+
+def evaluate_parameters(rule_parameters):
+    valid_rule_parameters = rule_parameters
+    return valid_rule_parameters
+
+####################
+# Helper Functions #
+####################
+
+# Build an error to be displayed in the logs when the parameter is invalid.
+def build_parameters_value_error_response(ex):
+    return  build_error_response(internal_error_message="Parameter value is invalid",
+                                 internal_error_details="An ValueError was raised during the validation of the Parameter value",
+                                 customer_error_code="InvalidParameterValueException",
+                                 customer_error_message=str(ex))
+
+# This gets the client after assuming the Config service role
+# either in the same AWS account or cross-account.
+def get_client(service, event):
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service)
+    credentials = get_assume_role_credentials(event["executionRoleArn"])
+    return boto3.client(service, aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken']
+                       )
+
+# This generate an evaluation for config
+def build_evaluation(resource_id, compliance_type, event, resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    eval_cc = {}
+    if annotation:
+        eval_cc['Annotation'] = annotation
+    eval_cc['ComplianceResourceType'] = resource_type
+    eval_cc['ComplianceResourceId'] = resource_id
+    eval_cc['ComplianceType'] = compliance_type
+    eval_cc['OrderingTimestamp'] = str(json.loads(event['invokingEvent'])['notificationCreationTime'])
+    return eval_cc
+
+def build_evaluation_from_config_item(configuration_item, compliance_type, annotation=None):
+    eval_ci = {}
+    if annotation:
+        eval_ci['Annotation'] = annotation
+    eval_ci['ComplianceResourceType'] = configuration_item['resourceType']
+    eval_ci['ComplianceResourceId'] = configuration_item['resourceId']
+    eval_ci['ComplianceType'] = compliance_type
+    eval_ci['OrderingTimestamp'] = configuration_item['configurationItemCaptureTime']
+    return eval_ci
+
+####################
+# Boilerplate Code #
+####################
+
+# Helper function used to validate input
+def check_defined(reference, reference_name):
+    if not reference:
+        raise Exception('Error: ', reference_name, 'is not defined')
+    return reference
+
+# Check whether the message is OversizedConfigurationItemChangeNotification or not
+def is_oversized_changed_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'OversizedConfigurationItemChangeNotification'
+
+# Check whether the message is a ScheduledNotification or not.
+def is_scheduled_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'ScheduledNotification'
+
+# Get configurationItem using getResourceConfigHistory API
+# in case of OversizedConfigurationItemChangeNotification
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1)
+    configuration_item = result['configurationItems'][0]
+    return convert_api_configuration(configuration_item)
+
+# Convert from the API model to the original invocation model
+def convert_api_configuration(configuration_item):
+    for k, v in configuration_item.items():
+        if isinstance(v, datetime.datetime):
+            configuration_item[k] = str(v)
+    configuration_item['awsAccountId'] = configuration_item['accountId']
+    configuration_item['ARN'] = configuration_item['arn']
+    configuration_item['configurationStateMd5Hash'] = configuration_item['configurationItemMD5Hash']
+    configuration_item['configurationItemVersion'] = configuration_item['version']
+    configuration_item['configuration'] = json.loads(configuration_item['configuration'])
+    if 'relationships' in configuration_item:
+        for i in range(len(configuration_item['relationships'])):
+            configuration_item['relationships'][i]['name'] = configuration_item['relationships'][i]['relationshipName']
+    return configuration_item
+
+# Based on the type of message get the configuration item
+# either from configurationItem in the invoking event
+# or using the getResourceConfigHistiry API in getConfiguration function.
+def get_configuration_item(invoking_event):
+    check_defined(invoking_event, 'invokingEvent')
+    if is_oversized_changed_notification(invoking_event['messageType']):
+        configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
+        return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
+    if is_scheduled_notification(invoking_event['messageType']):
+        return None
+    return check_defined(invoking_event['configurationItem'], 'configurationItem')
+
+# Check whether the resource has been deleted. If it has, then the evaluation is unnecessary.
+def is_applicable(configuration_item, event):
+    try:
+        check_defined(configuration_item, 'configurationItem')
+        check_defined(event, 'event')
+    except:
+        return True
+    status = configuration_item['configurationItemStatus']
+    event_left_scope = event['eventLeftScope']
+    if status == 'ResourceDeleted':
+        print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
+    return status in ('OK', 'ResourceDiscovered') and not event_left_scope
+
+def get_assume_role_credentials(role_arn):
+    sts_client = boto3.client('sts')
+    try:
+        assume_role_response = sts_client.assume_role(RoleArn=role_arn,
+                                                      RoleSessionName="configLambdaExecution",
+                                                      DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)
+        if 'liblogging' in sys.modules:
+            liblogging.logSession(role_arn, assume_role_response)
+        return assume_role_response['Credentials']
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        print(str(ex))
+        if 'AccessDenied' in ex.response['Error']['Code']:
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response['Error']['Message'] = "InternalError"
+            ex.response['Error']['Code'] = "InternalError"
+        raise ex
+
+# This removes older evaluation (usually useful for periodic rule not reporting on AWS::::Account).
+def clean_up_old_evaluations(latest_evaluations, event):
+
+    cleaned_evaluations = []
+
+    old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+        ConfigRuleName=event['configRuleName'],
+        ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+        Limit=100)
+
+    old_eval_list = []
+
+    while True:
+        for old_result in old_eval['EvaluationResults']:
+            old_eval_list.append(old_result)
+        if 'NextToken' in old_eval:
+            next_token = old_eval['NextToken']
+            old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+                ConfigRuleName=event['configRuleName'],
+                ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+                Limit=100,
+                NextToken=next_token)
+        else:
+            break
+
+    for old_eval in old_eval_list:
+        old_resource_id = old_eval['EvaluationResultIdentifier']['EvaluationResultQualifier']['ResourceId']
+        newer_founded = False
+        for latest_eval in latest_evaluations:
+            if old_resource_id == latest_eval['ComplianceResourceId']:
+                newer_founded = True
+        if not newer_founded:
+            cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
+
+    return cleaned_evaluations + latest_evaluations
+
+def lambda_handler(event, context):
+    if 'liblogging' in sys.modules:
+        liblogging.logEvent(event)
+
+    global AWS_CONFIG_CLIENT
+
+    #print(event)
+    check_defined(event, 'event')
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = {}
+    if 'ruleParameters' in event:
+        rule_parameters = json.loads(event['ruleParameters'])
+
+    try:
+        valid_rule_parameters = evaluate_parameters(rule_parameters)
+    except ValueError as ex:
+        return build_parameters_value_error_response(ex)
+
+    try:
+        AWS_CONFIG_CLIENT = get_client('config', event)
+        if invoking_event['messageType'] in ['ConfigurationItemChangeNotification', 'ScheduledNotification', 'OversizedConfigurationItemChangeNotification']:
+            configuration_item = get_configuration_item(invoking_event)
+            if is_applicable(configuration_item, event):
+                compliance_result = evaluate_compliance(event, configuration_item, valid_rule_parameters)
+            else:
+                compliance_result = "NOT_APPLICABLE"
+        else:
+            return build_internal_error_response('Unexpected message type', str(invoking_event))
+    except botocore.exceptions.ClientError as ex:
+        if is_internal_error(ex):
+            return build_internal_error_response("Unexpected error while completing API request", str(ex))
+        return build_error_response("Customer error while making API request", str(ex), ex.response['Error']['Code'], ex.response['Error']['Message'])
+    except ValueError as ex:
+        return build_internal_error_response(str(ex), str(ex))
+
+    evaluations = []
+    latest_evaluations = []
+
+    if not compliance_result:
+        latest_evaluations.append(build_evaluation(event['accountId'], "NOT_APPLICABLE", event, resource_type='AWS::::Account'))
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, str):
+        if configuration_item:
+            evaluations.append(build_evaluation_from_config_item(configuration_item, compliance_result))
+        else:
+            evaluations.append(build_evaluation(event['accountId'], compliance_result, event, resource_type=DEFAULT_RESOURCE_TYPE))
+    elif isinstance(compliance_result, list):
+        for evaluation in compliance_result:
+            missing_fields = False
+            for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+                if field not in evaluation:
+                    print("Missing " + field + " from custom evaluation.")
+                    missing_fields = True
+
+            if not missing_fields:
+                latest_evaluations.append(evaluation)
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, dict):
+        missing_fields = False
+        for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+            if field not in compliance_result:
+                print("Missing " + field + " from custom evaluation.")
+                missing_fields = True
+        if not missing_fields:
+            evaluations.append(compliance_result)
+    else:
+        evaluations.append(build_evaluation_from_config_item(configuration_item, 'NOT_APPLICABLE'))
+
+    # Put together the request that reports the evaluation status
+    result_token = event['resultToken']
+    test_mode = False
+    if result_token == 'TESTMODE':
+        # Used solely for RDK test to skip actual put_evaluation API call
+        test_mode = True
+
+    # Invoke the Config API to report the result of the evaluation
+    evaluation_copy = []
+    evaluation_copy = evaluations[:]
+    while evaluation_copy:
+        AWS_CONFIG_CLIENT.put_evaluations(Evaluations=evaluation_copy[:100], ResultToken=result_token, TestMode=test_mode)
+        del evaluation_copy[:100]
+
+    # Used solely for RDK test to be able to test Lambda function
+    return evaluations
+
+def is_internal_error(exception):
+    return ((not isinstance(exception, botocore.exceptions.ClientError)) or exception.response['Error']['Code'].startswith('5')
+            or 'InternalError' in exception.response['Error']['Code'] or 'ServiceError' in exception.response['Error']['Code'])
+
+def build_internal_error_response(internal_error_message, internal_error_details=None):
+    return build_error_response(internal_error_message, internal_error_details, 'InternalError', 'InternalError')
+
+def build_error_response(internal_error_message, internal_error_details=None, customer_error_code=None, customer_error_message=None):
+    error_response = {
+        'internalErrorMessage': internal_error_message,
+        'internalErrorDetails': internal_error_details,
+        'customerErrorMessage': customer_error_message,
+        'customerErrorCode': customer_error_code
+    }
+    print(error_response)
+    return error_response

--- a/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY_test.py
+++ b/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY_test.py
@@ -1,0 +1,281 @@
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the License is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import sys
+import unittest
+from botocore.exceptions import ClientError
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::EC2::VPC'
+
+#############
+# Main Code #
+#############
+
+CONFIG_CLIENT_MOCK = MagicMock()
+STS_CLIENT_MOCK = MagicMock()
+EC2_CLIENT_MOCK = MagicMock()
+IAM_CLIENT_MOCK = MagicMock()
+
+class Boto3Mock():
+    @staticmethod
+    def client(client_name, *args, **kwargs):
+        if client_name == 'config':
+            return CONFIG_CLIENT_MOCK
+        if client_name == 'sts':
+            return STS_CLIENT_MOCK
+        if client_name == 'ec2':
+            return EC2_CLIENT_MOCK
+        if client_name == 'iam':
+            return IAM_CLIENT_MOCK
+        raise Exception("Attempting to create an unknown client")
+
+sys.modules['boto3'] = Boto3Mock()
+
+RULE = __import__('vpc-interface-endpoint-open-policy')
+
+class ComplianceTest(unittest.TestCase):
+     # Unit test for no VPC is present -- GHERKIN Scenario 1
+    def test_scenario_1(self):
+        EC2_CLIENT_MOCK.reset_mock()
+        describevpc_return = {"Vpcs":[]}
+        EC2_CLIENT_MOCK.describe_vpcs = MagicMock(return_value=describevpc_return)
+        resp_expected = []
+        response = RULE.lambda_handler(build_lambda_scheduled_event(), {})
+        resp_expected.append(build_expected_response('NOT_APPLICABLE', '123456789012', compliance_resource_type='AWS::EC2::VPC'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #  Scenario 2: At least one VPC is present and no interface endpoint is present on DescribeVpcEndpoints API -- GHERKIN Scenario 2
+    def test_scenario_2(self):
+        EC2_CLIENT_MOCK.reset_mock()
+        vpc_id = "vpc-1234567"
+        describevpc_return = {"Vpcs":[{"VpcId":vpc_id}]}
+        EC2_CLIENT_MOCK.describe_vpcs = MagicMock(return_value=describevpc_return)
+        describevpcendpoints_return = {"VpcEndpoints":[]}
+        EC2_CLIENT_MOCK.describe_vpc_endpoints = MagicMock(return_value=describevpcendpoints_return)
+        resp_expected = []
+        response = RULE.lambda_handler(build_lambda_scheduled_event(), {})
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'vpc-1234567', compliance_resource_type='AWS::EC2::VPC', annotation='There are no VPC interface endpoints present in '+ vpc_id+'.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Unit test for when Amazon VPC has a AWS S3 VPC present but is not in available state -- Gherkin Scenario 3
+    def test_scenario_3(self):
+        EC2_CLIENT_MOCK.reset_mock()
+        resp_expected = []
+        vpc_id = "vpc-1234567"
+        vpc_return = {'Vpcs':[{'VpcId':'vpc-1234567'}]}
+        EC2_CLIENT_MOCK.describe_vpcs = MagicMock(return_value=vpc_return)
+        describevpcendpoints_return = {
+            "VpcEndpoints": [
+                {
+                    "VpcEndpointId": "vpce-06e48c97f0bc5d501",
+                    "VpcEndpointType": "Interface",
+                    "VpcId": "vpc-0056487b",
+                    "ServiceName": "com.amazonaws.us-east-1.s3",
+                    "State": "pending",
+                    "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                    "RouteTableIds": [
+                        "rtb-0ba1ba4f40636b1fd"
+                    ]
+                }
+            ]
+        }
+        simulatecustompolicy_return = {
+            'EvaluationResults': [
+                {
+                    'EvalActionName': 's3:PutObject',
+                    'EvalResourceName': 'string',
+                    'EvalDecision': 'allowed',
+                },
+                {
+                    'EvalActionName': 's3:PutObjectVersion',
+                    'EvalResourceName': 'string',
+                    'EvalDecision': 'allowed',
+                }
+            ]
+        }
+        EC2_CLIENT_MOCK.describe_vpc_endpoints = MagicMock(return_value=describevpcendpoints_return)
+        IAM_CLIENT_MOCK.simulate_custom_policy = MagicMock(return_value=simulatecustompolicy_return)
+        response = RULE.lambda_handler(build_lambda_scheduled_event(), {})
+        resp_expected.append(build_expected_response('NON_COMPLIANT', 'vpc-1234567', compliance_resource_type='AWS::EC2::VPC', annotation='The interface VPC endpoint (vpce-06e48c97f0bc5d501) is using the default open policy in VPC '+vpc_id+'.'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+    #Unit test for VPC is present, and S3 endpoint is present in available state -- Gherkin Scenario 4
+    def test_scenario_4(self):
+        EC2_CLIENT_MOCK.reset_mock()
+        resp_expected = []
+        vpc_return = {'Vpcs':[{'VpcId':'vpc-1234567'}]}
+        EC2_CLIENT_MOCK.describe_vpcs = MagicMock(return_value=vpc_return)
+        describevpcendpoints_return = {
+            "VpcEndpoints": [
+                {
+                    "VpcEndpointId": "vpce-06e48c97f0bc5d501",
+                    "VpcEndpointType": "Gateway",
+                    "VpcId": "vpc-0056487b",
+                    "ServiceName": "com.amazonaws.us-east-1.s3",
+                    "State": "available",
+                    "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                    "RouteTableIds": [
+                        "rtb-0ba1ba4f40636b1fd"
+                    ]
+                },
+                {
+                    "VpcEndpointId": "vpce-03ff48d1f2709aa88",
+                    "VpcEndpointType": "Interface",
+                    "VpcId": "vpc-0056487b",
+                    "ServiceName": "com.amazonaws.us-east-1.secretsmanager",
+                    "State": "available",
+                    "PolicyDocument": "{\n  \"Statement\": [\n    {\n      \"Action\": \"*\", \n      \"Effect\": \"Deny\", \n      \"Principal\": \"*\", \n      \"Resource\": \"*\"\n    }\n  ]\n}",
+                    "RouteTableIds": [],
+                    "SubnetIds": [
+                        "subnet-711b7d3b"
+                    ]
+                }
+            ]
+        }
+        simulatecustompolicy_return = {
+            'EvaluationResults': [
+                {
+                    'EvalActionName': 's3:PutObject',
+                    'EvalResourceName': 'string',
+                    'EvalDecision': 'explicitDeny',
+                },
+                {
+                    'EvalActionName': 's3:PutObjectVersion',
+                    'EvalResourceName': 'string',
+                    'EvalDecision': 'explicitDeny',
+                }
+            ]
+        }
+        EC2_CLIENT_MOCK.describe_vpc_endpoints = MagicMock(return_value=describevpcendpoints_return)
+        IAM_CLIENT_MOCK.simulate_custom_policy = MagicMock(return_value=simulatecustompolicy_return)
+        response = RULE.lambda_handler(build_lambda_scheduled_event(), {})
+        resp_expected.append(build_expected_response('COMPLIANT', 'vpc-1234567', compliance_resource_type='AWS::EC2::VPC'))
+        assert_successful_evaluation(self, response, resp_expected)
+
+####################
+# Helper Functions #
+####################
+
+def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_lambda_scheduled_event(rule_parameters=None):
+    invoking_event = '{"messageType":"ScheduledNotification","notificationCreationTime":"2017-12-23T22:11:18.158Z"}'
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_expected_response(compliance_type, compliance_resource_id, compliance_resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    if not annotation:
+        return {
+            'ComplianceType': compliance_type,
+            'ComplianceResourceId': compliance_resource_id,
+            'ComplianceResourceType': compliance_resource_type
+            }
+    return {
+        'ComplianceType': compliance_type,
+        'ComplianceResourceId': compliance_resource_id,
+        'ComplianceResourceType': compliance_resource_type,
+        'Annotation': annotation
+        }
+
+def assert_successful_evaluation(test_class, response, resp_expected, evaluations_count=1):
+    if isinstance(response, dict):
+        test_class.assertEquals(resp_expected['ComplianceResourceType'], response['ComplianceResourceType'])
+        test_class.assertEquals(resp_expected['ComplianceResourceId'], response['ComplianceResourceId'])
+        test_class.assertEquals(resp_expected['ComplianceType'], response['ComplianceType'])
+        test_class.assertTrue(response['OrderingTimestamp'])
+        if 'Annotation' in resp_expected or 'Annotation' in response:
+            test_class.assertEquals(resp_expected['Annotation'], response['Annotation'])
+    elif isinstance(response, list):
+        test_class.assertEquals(evaluations_count, len(response))
+        for i, response_expected in enumerate(resp_expected):
+            test_class.assertEquals(response_expected['ComplianceResourceType'], response[i]['ComplianceResourceType'])
+            test_class.assertEquals(response_expected['ComplianceResourceId'], response[i]['ComplianceResourceId'])
+            test_class.assertEquals(response_expected['ComplianceType'], response[i]['ComplianceType'])
+            test_class.assertTrue(response[i]['OrderingTimestamp'])
+            if 'Annotation' in response_expected or 'Annotation' in response[i]:
+                test_class.assertEquals(response_expected['Annotation'], response[i]['Annotation'])
+
+def assert_customer_error_response(test_class, response, customer_error_code=None, customer_error_message=None):
+    if customer_error_code:
+        test_class.assertEqual(customer_error_code, response['customerErrorCode'])
+    if customer_error_message:
+        test_class.assertEqual(customer_error_message, response['customerErrorMessage'])
+    test_class.assertTrue(response['customerErrorCode'])
+    test_class.assertTrue(response['customerErrorMessage'])
+    if "internalErrorMessage" in response:
+        test_class.assertTrue(response['internalErrorMessage'])
+    if "internalErrorDetails" in response:
+        test_class.assertTrue(response['internalErrorDetails'])
+
+def sts_mock():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string"}}
+    STS_CLIENT_MOCK.reset_mock(return_value=True)
+    STS_CLIENT_MOCK.assume_role = MagicMock(return_value=assume_role_response)
+
+##################
+# Common Testing #
+##################
+
+class TestStsErrors(unittest.TestCase):
+
+    def test_sts_unknown_error(self):
+        RULE.ASSUME_ROLE_MODE = True
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=ClientError(
+            {'Error': {'Code': 'unknown-code', 'Message': 'unknown-message'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'InternalError', 'InternalError')
+
+    def test_sts_access_denied(self):
+        RULE.ASSUME_ROLE_MODE = True
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'AccessDenied', 'AWS Config does not have permission to assume the IAM role.')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY_test.py
+++ b/python/VPC_ENDPOINT_DEFAULT_POLICY/VPC_ENDPOINT_DEFAULT_POLICY_test.py
@@ -48,7 +48,7 @@ class Boto3Mock():
 
 sys.modules['boto3'] = Boto3Mock()
 
-RULE = __import__('vpc-interface-endpoint-open-policy')
+RULE = __import__('VPC_ENDPOINT_DEFAULT_POLICY')
 
 class ComplianceTest(unittest.TestCase):
      # Unit test for no VPC is present -- GHERKIN Scenario 1

--- a/python/VPC_ENDPOINT_DEFAULT_POLICY/parameter.json
+++ b/python/VPC_ENDPOINT_DEFAULT_POLICY/parameter.json
@@ -1,10 +1,10 @@
 {
     "Version": "1.0", 
     "Parameters": {
-      "CodeKey": "vpc-interface-endpoint-open-policy.zip", 
+      "CodeKey": "VPC_ENDPOINT_DEFAULT_POLICY.zip", 
       "SourceRuntime": "python3.7", 
       "SourcePeriodic": "TwentyFour_Hours", 
-      "RuleName": "vpc-interface-endpoint-open-policy", 
+      "RuleName": "VPC_ENDPOINT_DEFAULT_POLICY", 
       "OptionalParameters": "{}", 
       "InputParameters": "{}"
     }, 

--- a/python/VPC_ENDPOINT_DEFAULT_POLICY/parameter.json
+++ b/python/VPC_ENDPOINT_DEFAULT_POLICY/parameter.json
@@ -1,0 +1,12 @@
+{
+    "Version": "1.0", 
+    "Parameters": {
+      "CodeKey": "vpc-interface-endpoint-open-policy.zip", 
+      "SourceRuntime": "python3.7", 
+      "SourcePeriodic": "TwentyFour_Hours", 
+      "RuleName": "vpc-interface-endpoint-open-policy", 
+      "OptionalParameters": "{}", 
+      "InputParameters": "{}"
+    }, 
+    "Tags": "[]"
+  }


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
This PR includes test that tests each VPCe (Gateway and Interface) has a resource policy attached that does not allow all actions (i.e. the default). This manages several attack vectors for bad actors to use to exfiltrate data from a compromised account.