### PR TITLE
Lowercasing TRUE for IAM password policy checks

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Top20.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Top20.yaml
@@ -40,16 +40,16 @@ Parameters:
     Default: '24'
     Type: String
   IamPasswordPolicyParamRequireLowercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireNumbers:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireSymbols:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireUppercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
     Default: '90'


### PR DESCRIPTION
he values for true and false in iam-password-policy are case-sensitive. If true is not provided in lowercase, it will be treated as false.
https://docs.aws.amazon.com/config/latest/developerguide/iam-password-policy.html

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
