### PR TITLE
Corrects typo in Config Rule name for CheckForEc2VolumesInUse

### DIFF
--- a/aws-config-conformance-packs/AWS-Control-Tower-Detective-Guardrails.yaml
+++ b/aws-config-conformance-packs/AWS-Control-Tower-Detective-Guardrails.yaml
@@ -25,7 +25,7 @@ Resources:
   CheckForEc2VolumesInUse:
     Type: AWS::Config::ConfigRule
     Properties:
-      ConfigRuleName: CheckForEc2VolumesInUs
+      ConfigRuleName: CheckForEc2VolumesInUse
       Description: Disallow EBS volumes that are unattached to an EC2 instance - Checks whether EBS volumes are attached to EC2 instances
       InputParameters:
         deleteOnTermination: true


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)
