### PR TITLE
Removing DLQ check rule

### DIFF
--- a/aws-config-conformance-packs/Security-Best-Practices-for-Lambda.yaml
+++ b/aws-config-conformance-packs/Security-Best-Practices-for-Lambda.yaml
@@ -14,16 +14,6 @@ Parameters:
       python3.6, ruby2.7, java11, java8, java8.al2, go1.x, dotnetcore3.1, dotnet6
     Type: String
 Resources:
-  LambdaDlqCheck:
-    Properties:
-      ConfigRuleName: lambda-dlq-check
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::Lambda::Function
-      Source:
-        Owner: AWS
-        SourceIdentifier: LAMBDA_DLQ_CHECK
-    Type: AWS::Config::ConfigRule
   LambdaFunctionSettingsCheck:
     Properties:
       ConfigRuleName: lambda-function-settings-check


### PR DESCRIPTION
Hello, currently the recommended way for handling failures of Lambda functions is to use Lambda **Destinations**, not **DLQ**s. I couldn't find an AWS managed rule for Lambda Destinations, so currently the replacement would be to create a custom rule that checks if you are using Destinations for your Lambdas.

**https://aws.amazon.com/blogs/compute/introducing-aws-lambda-destinations/** 

> Dead Letter Queues (DLQ) have been available since 2016 and are a great way to handle asynchronous failure situations. Destinations provide more useful capabilities by passing additional function execution information, including code exception stack traces, to more destination services.
> 
> Destinations and DLQs can be used together and at the same time although Destinations should be considered a more **preferred solution**

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)
