### PR TITLE
Added to Operational-Best-Practices-for-HIPAA-Security.yaml ability t…

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
@@ -55,6 +55,12 @@ Parameters:
   IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
     Default: '90'
     Type: String
+  InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds:
+    Default: ''
+    Type: String
+  NoUnrestrictedRouteToIgwParamRouteTableIds:
+    Default: ''
+    Type: String
   RedshiftClusterConfigurationCheckParamClusterDbEncrypted:
     Default: 'TRUE'
     Type: String
@@ -817,6 +823,12 @@ Resources:
   InternetGatewayAuthorizedVpcOnly:
     Properties:
       ConfigRuleName: internet-gateway-authorized-vpc-only
+      InputParameters:
+        AuthorizedVpcIds:
+          Fn::If:
+          - internetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
+          - Ref: InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
+          - Ref: AWS::NoValue
       Scope:
         ComplianceResourceTypes:
         - AWS::EC2::InternetGateway
@@ -871,6 +883,12 @@ Resources:
   NoUnrestrictedRouteToIgw:
     Properties:
       ConfigRuleName: no-unrestricted-route-to-igw
+      InputParameters:
+        routeTableIds:
+          Fn::If:
+          - noUnrestrictedRouteToIgwParamRouteTableIds
+          - Ref: NoUnrestrictedRouteToIgwParamRouteTableIds
+          - Ref: AWS::NoValue
       Scope:
         ComplianceResourceTypes:
         - AWS::EC2::RouteTable
@@ -1505,6 +1523,16 @@ Conditions:
     - Fn::Equals:
       - ''
       - Ref: IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge
+  internetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds:
+    Fn::Not:
+    - Fn::Equals:
+      - ''
+      - Ref: InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
+  noUnrestrictedRouteToIgwParamRouteTableIds:
+    Fn::Not:
+    - Fn::Equals:
+      - ''
+      - Ref: NoUnrestrictedRouteToIgwParamRouteTableIds
   redshiftClusterConfigurationCheckParamClusterDbEncrypted:
     Fn::Not:
     - Fn::Equals:


### PR DESCRIPTION
…o handle "routeTableIds" and "AuthorizedVpcIds" input parameters.

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
References to similar issues or PR:
https://github.com/awslabs/aws-config-rules/issues/393
https://github.com/awslabs/aws-config-rules/pull/356/files

*Description of changes:*
Added InputParamenters to pass 
- AuthorizedVpcIds for rule INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY
- routeTableIds for rule NO_UNRESTRICTED_ROUTE_TO_IGW