### PR TITLE
Fix CCN ENS Medium

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
@@ -31,6 +31,12 @@ Parameters:
   IamPasswordPolicyParamRequireUppercaseCharacters:
     Default: 'true'
     Type: String
+  RedshiftClusterConfigurationCheckParamClusterDbEncrypted:
+    Default: 'true'
+    Type: String
+  RedshiftClusterConfigurationCheckParamLoggingEnabled:
+    Default: 'true'
+    Type: String
   RestrictedIncomingTrafficParamBlockedPort1:
     Default: '20'
     Type: String
@@ -806,8 +812,16 @@ Resources:
     Properties:
       ConfigRuleName: redshift-cluster-configuration-check
       InputParameters:
-        clusterDbEncrypted: 'TRUE'
-        loggingEnabled: 'TRUE'
+        clusterDbEncrypted:
+          Fn::If:
+          - redshiftClusterConfigurationCheckParamClusterDbEncrypted
+          - Ref: RedshiftClusterConfigurationCheckParamClusterDbEncrypted
+          - Ref: AWS::NoValue
+        loggingEnabled:
+          Fn::If:
+          - redshiftClusterConfigurationCheckParamLoggingEnabled
+          - Ref: RedshiftClusterConfigurationCheckParamLoggingEnabled
+          - Ref: AWS::NoValue
       Scope:
         ComplianceResourceTypes:
         - AWS::Redshift::Cluster
@@ -1228,6 +1242,16 @@ Conditions:
     - Fn::Equals:
       - ''
       - Ref: IamPasswordPolicyParamRequireUppercaseCharacters
+  redshiftClusterConfigurationCheckParamClusterDbEncrypted:
+    Fn::Not:
+    - Fn::Equals:
+      - ''
+      - Ref: RedshiftClusterConfigurationCheckParamClusterDbEncrypted
+  redshiftClusterConfigurationCheckParamLoggingEnabled:
+    Fn::Not:
+    - Fn::Equals:
+      - ''
+      - Ref: RedshiftClusterConfigurationCheckParamLoggingEnabled
   restrictedIncomingTrafficParamBlockedPort1:
     Fn::Not:
     - Fn::Equals:

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
@@ -829,16 +829,6 @@ Resources:
         Owner: AWS
         SourceIdentifier: REDSHIFT_CLUSTER_CONFIGURATION_CHECK
     Type: AWS::Config::ConfigRule
-  RedshiftClusterConfigurationCheck2:
-    Properties:
-      ConfigRuleName: redshift-cluster-configuration-check-2
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::Redshift::Cluster
-      Source:
-        Owner: AWS
-        SourceIdentifier: REDSHIFT_CLUSTER_CONFIGURATION_CHECK
-    Type: AWS::Config::ConfigRule
   RedshiftClusterKmsEnabled:
     Properties:
       ConfigRuleName: redshift-cluster-kms-enabled


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

resolves #407

*Description of changes:*

* [Standardize RedshiftClusterConfigurationCheck across Low-Medium-High](https://github.com/awslabs/aws-config-rules/commit/2e3dfd8e49212059ca013c707d850ab9f67184fa): Levels Low and High share the same design for this check but Medium somehow not.
* [Remove failing check RedshiftClusterConfigurationCheck2](https://github.com/awslabs/aws-config-rules/commit/4d2fef1455e2732e6c8006d124b9390ea027b3bc): Remove the `RedshiftClusterConfigurationCheck2` which is not present in the [Security Best Practices for Redshift template](https://github.com/awslabs/aws-config-rules/blob/master/aws-config-conformance-packs/Security-Best-Practices-for-Redshift.yaml), and also not present in the [Low](https://github.com/awslabs/aws-config-rules/blob/edf8d76e8ce281a81a166d68381f5f644098c98c/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Low.yaml) and [High](https://github.com/awslabs/aws-config-rules/blob/edf8d76e8ce281a81a166d68381f5f644098c98c/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-High.yaml) versions of the CCN ENS template. Moreover, the `SourceIdentifier` is [REDSHIFT_CLUSTER_CONFIGURATION_CHECK](https://docs.aws.amazon.com/config/latest/developerguide/redshift-cluster-configuration-check.html) which states that both parameters `clusterDbEncrypted` and `loggingEnabled` are mandatory. The check `RedshiftClusterConfigurationCheck2` makes no sense as is wrongly trying to check something that it's being already checked in `RedshiftClusterConfigurationCheck`.