### PR TITLE
Update Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
@@ -10,6 +10,12 @@
 ##################################################################################
 
 Parameters:
+  InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds:
+    Default: ''
+    Type: String
+  NoUnrestrictedRouteToIgwParamRouteTableIds:
+    Default: ''
+    Type: String
   AccessKeysRotatedParamMaxAccessKeyAge:
     Default: '90'
     Type: String
@@ -871,6 +877,8 @@ Resources:
       Source:
         Owner: AWS
         SourceIdentifier: INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY
+      InputParameters:
+        AuthorizedVpcIds: !Ref InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
     Type: AWS::Config::ConfigRule
   KinesisStreamEncrypted:
     Properties:
@@ -945,6 +953,8 @@ Resources:
       Source:
         Owner: AWS
         SourceIdentifier: NO_UNRESTRICTED_ROUTE_TO_IGW
+      InputParameters:
+        routeTableIds: !Ref NoUnrestrictedRouteToIgwParamRouteTableIds
     Type: AWS::Config::ConfigRule
   OpensearchEncryptedAtRest:
     Properties:


### PR DESCRIPTION
Add Parameters for InternetGatewayAuthorizedVpcOnly and NoUnrestrictedRouteToIgw

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
