### PR TITLE
Align Cloud-Trail rules with current public naming of config rules

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
@@ -195,7 +195,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -909,7 +909,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED


### PR DESCRIPTION
Update cloudtrail-enabled and multi-region-cloudtrail-enabled config rules per https://docs.aws.amazon.com/config/latest/developerguide/cloudtrail-enabled.html and https://docs.aws.amazon.com/config/latest/developerguide/multi-region-cloudtrail-enabled.html

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Description of changes:*

See diff.