### PR TITLE
update cloudtrail-enabled to match config rule

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-For-NIST-800-181.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-For-NIST-800-181.yaml
@@ -271,7 +271,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -956,7 +956,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Material.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Material.yaml
@@ -252,7 +252,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -937,7 +937,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Standard.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Standard.yaml
@@ -244,7 +244,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -889,7 +889,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ACSC-Essential8.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ACSC-Essential8.yaml
@@ -262,7 +262,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -826,7 +826,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ACSC-ISM.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ACSC-ISM.yaml
@@ -235,7 +235,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -805,7 +805,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-API-Gateway.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-API-Gateway.yaml
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-APRA-CPG-234.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-APRA-CPG-234.yaml
@@ -234,7 +234,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -909,7 +909,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Reliability-Pillar.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Reliability-Pillar.yaml
@@ -142,7 +142,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -480,7 +480,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Security-Pillar.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Security-Pillar.yaml
@@ -864,7 +864,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-BNM-RMiT.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-BNM-RMiT.yaml
@@ -238,7 +238,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -926,7 +926,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCCS-Medium.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCCS-Medium.yaml
@@ -226,7 +226,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -932,7 +932,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-High.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-High.yaml
@@ -154,7 +154,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -686,7 +686,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Low.yaml
@@ -145,7 +145,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -647,7 +647,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
@@ -139,7 +139,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -648,7 +648,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-FB-v1.3-Level1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-FB-v1.3-Level1.yaml
@@ -167,7 +167,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-FB-v1.3-Level2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-FB-v1.3-Level2.yaml
@@ -195,7 +195,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level1.yaml
@@ -233,7 +233,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-AWS-v1.4-Level2.yaml
@@ -268,7 +268,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG1.yaml
@@ -142,7 +142,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -676,7 +676,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG2.yaml
@@ -179,7 +179,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -871,7 +871,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG3.yaml
@@ -189,7 +189,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -881,7 +881,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Top20.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Top20.yaml
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -613,7 +613,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CISA-Cyber-Essentials.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CISA-Cyber-Essentials.yaml
@@ -849,7 +849,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CJIS.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CJIS.yaml
@@ -789,7 +789,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-1.yaml
@@ -513,7 +513,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-2.yaml
@@ -244,7 +244,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -933,7 +933,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-1.yaml
@@ -147,7 +147,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -515,7 +515,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-2.yaml
@@ -240,7 +240,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -828,7 +828,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-3.yaml
@@ -425,7 +425,7 @@ Resources:
     - SI.2.216
     - SI.2.217
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Description: Checks whether AWS CloudTrail is enabled in your AWS account.
       Source:
         Owner: AWS
@@ -1651,7 +1651,7 @@ Resources:
     - SI.2.216
     - SI.2.217
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Description: Checks that there is at least one multi-region AWS CloudTrail.
         The rule is non-compliant if the trails do not match input parameters
       Source:

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-4.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-4.yaml
@@ -259,7 +259,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -948,7 +948,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-5.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-5.yaml
@@ -259,7 +259,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -948,7 +948,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ENISA-Cybersecurity-Guide.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ENISA-Cybersecurity-Guide.yaml
@@ -224,7 +224,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FDA-21CFR-Part-11.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FDA-21CFR-Part-11.yaml
@@ -181,7 +181,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -848,7 +848,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FFIEC.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FFIEC.yaml
@@ -278,7 +278,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -945,7 +945,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
@@ -257,7 +257,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -957,7 +957,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP.yaml
@@ -260,7 +260,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -1006,7 +1006,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Germany-C5.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Germany-C5.yaml
@@ -271,7 +271,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -862,7 +862,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-GxP-EU-Annex-11.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-GxP-EU-Annex-11.yaml
@@ -92,7 +92,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -521,7 +521,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
@@ -232,7 +232,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -863,7 +863,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-IRS-1075.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-IRS-1075.yaml
@@ -171,7 +171,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-KISMS.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-KISMS.yaml
@@ -260,7 +260,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -899,7 +899,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Logging.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Logging.yaml
@@ -41,7 +41,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -131,7 +131,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-MAS-TRMG.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-MAS-TRMG.yaml
@@ -223,7 +223,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -836,7 +836,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Management-Governance-Services.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Management-Governance-Services.yaml
@@ -50,7 +50,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -196,7 +196,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NBC-TRMG.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NBC-TRMG.yaml
@@ -234,7 +234,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -896,7 +896,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
@@ -220,7 +220,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -931,7 +931,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-1800-25.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-1800-25.yaml
@@ -210,7 +210,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
@@ -195,7 +195,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -909,7 +909,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-4.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-4.yaml
@@ -182,7 +182,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -774,7 +774,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-5.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-5.yaml
@@ -228,7 +228,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -873,7 +873,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-CSF.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-CSF.yaml
@@ -217,7 +217,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -815,7 +815,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-Privacy-Framework.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-Privacy-Framework.yaml
@@ -252,7 +252,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NYDFS-23-NYCRR-500.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NYDFS-23-NYCRR-500.yaml
@@ -266,7 +266,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -840,7 +840,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NZISM.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NZISM.yaml
@@ -154,7 +154,7 @@ Resources:
     Controls: ['1998', '2013', '6860', '7496']
     Type: AWS::Config::ConfigRule
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-PCI-DSS.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-PCI-DSS.yaml
@@ -248,7 +248,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -832,7 +832,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-Basic-Cyber-Security-Framework.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-Basic-Cyber-Security-Framework.yaml
@@ -242,7 +242,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -729,7 +729,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-MasterDirection.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-MasterDirection.yaml
@@ -295,7 +295,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -943,7 +943,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-SWIFT-CSP.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-SWIFT-CSP.yaml
@@ -160,7 +160,7 @@ Resources:
     Controls:
     - '6.4'
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Description: Checks whether AWS CloudTrail is enabled in your AWS account.
       Source:
         Owner: AWS

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Security-Services.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Security-Services.yaml
@@ -155,7 +155,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -438,7 +438,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED

--- a/aws-config-conformance-packs/Security-Best-Practices-for-CloudTrail.yaml
+++ b/aws-config-conformance-packs/Security-Best-Practices-for-CloudTrail.yaml
@@ -17,7 +17,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -52,7 +52,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Description of changes:*

Update cloudtrail-enabled and multi-region-cloudtrail-enabled config rules per https://docs.aws.amazon.com/config/latest/developerguide/cloudtrail-enabled.html and https://docs.aws.amazon.com/config/latest/developerguide/multi-region-cloudtrail-enabled.html