### PR TITLE
Updated Operational-Best-Practices-for-HIPAA-Security template to inc…

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
@@ -55,6 +55,9 @@ Parameters:
   IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
     Default: '90'
     Type: String
+  InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds:
+    Default: ''
+    Type: String
   RedshiftClusterConfigurationCheckParamClusterDbEncrypted:
     Default: 'TRUE'
     Type: String
@@ -823,6 +826,12 @@ Resources:
       Source:
         Owner: AWS
         SourceIdentifier: INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY
+      InputParameters:
+        AuthorizedVpcIds:
+          Fn::If:
+          - internetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
+          - Ref: InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
+          - Ref: AWS::NoValue
     Type: AWS::Config::ConfigRule
   KinesisStreamEncrypted:
     Properties:
@@ -1505,6 +1514,11 @@ Conditions:
     - Fn::Equals:
       - ''
       - Ref: IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge
+  internetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds:
+    Fn::Not:
+    - Fn::Equals:
+      - ''
+      - Ref: InternetGatewayAuthorizedVpcOnlyParamAuthorizedVpcIds
   redshiftClusterConfigurationCheckParamClusterDbEncrypted:
     Fn::Not:
     - Fn::Equals:


### PR DESCRIPTION
…lude input params for InternetGatewayAuthorizedVpcOnly config rule

I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:*
Updated the Operational-Best-Practices-for-HIPAA-Security template to include AuthorizedVpcIds as an input parameter and set default to AWS::NoValue. 