### PR TITLE
Update names for FedRAMP High cpack templates

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
@@ -1,9 +1,9 @@
 ##################################################################################
 #
 #   Conformance Pack:
-#     Operational Best Practices for FedRAMP(Moderate)
+#     Operational Best Practices for FedRAMP (High Part 1)
 #
-#   This conformance pack helps verify compliance with FedRAMP(Moderate) requirements.
+#   This conformance pack helps verify compliance with FedRAMP (High Part 1) requirements.
 #
 #   See Parameters section for names and descriptions of required parameters.
 #

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
@@ -1,9 +1,9 @@
 ##################################################################################
 #
 #   Conformance Pack:
-#     Operational Best Practices for FedRAMP (High)
+#     Operational Best Practices for FedRAMP (High Part 2)
 #
-#   This conformance pack helps verify compliance with FedRAMP (High) requirements.
+#   This conformance pack helps verify compliance with FedRAMP (High Part 2) requirements.
 #
 #   See Parameters section for names and descriptions of required parameters.
 #


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
OW-4886

*Description of changes:*
Updating the names and descriptions of the new Operational Best Practices for FedRAMP High conformance pack templates