### PR TITLE
Fix typo and reword comment in ‘find_violation’ function

### DIFF
--- a/python/ec2_require_tags_with_valid_values.py
+++ b/python/ec2_require_tags_with_valid_values.py
@@ -18,8 +18,8 @@ import boto3
 APPLICABLE_RESOURCES = ["AWS::EC2::Instance"]
 
 
-# Iterate through required tags ensureing each required tag is present, 
-# and value is one of the given valid values
+# Iterate through the required tags, ensuring each required tag is present
+# and that the value is one of the given valid values
 def find_violation(current_tags, required_tags):
     violation = ""
     for rtag,rvalues in required_tags.iteritems():


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Description of changes:*
Fix "ensureing" typo and reword the comment so it's clearer to read.