### PR TITLE
Adding RDS Multi-AZ cluster wherever instance level rule exists

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-For-NIST-800-181.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-For-NIST-800-181.yaml
@@ -1038,6 +1038,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Material.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Material.yaml
@@ -1009,6 +1009,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Standard.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-ABS-CCIGv2-Standard.yaml
@@ -953,6 +953,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-APRA-CPG-234.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-APRA-CPG-234.yaml
@@ -991,6 +991,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Reliability-Pillar.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-AWS-Well-Architected-Reliability-Pillar.yaml
@@ -562,6 +562,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-BCP-and-DR.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-BCP-and-DR.yaml
@@ -294,6 +294,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RedshiftBackupEnabled:
     Properties:
       ConfigRuleName: redshift-backup-enabled

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-High.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-High.yaml
@@ -807,6 +807,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Low.yaml
@@ -768,6 +768,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CCN-ENS-Medium.yaml
@@ -769,6 +769,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG2.yaml
@@ -966,6 +966,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CIS-Critical-Security-Controls-v8-IG3.yaml
@@ -976,6 +976,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CISA-Cyber-Essentials.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CISA-Cyber-Essentials.yaml
@@ -1001,6 +1001,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-2.0-Level-2.yaml
@@ -1044,6 +1044,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-3.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-3.yaml
@@ -1846,6 +1846,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Controls:
     - IA.2.081

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-4.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-4.yaml
@@ -1059,6 +1059,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-5.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-CMMC-Level-5.yaml
@@ -1059,6 +1059,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-Database-Services.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-Database-Services.yaml
@@ -186,6 +186,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FDA-21CFR-Part-11.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FDA-21CFR-Part-11.yaml
@@ -930,6 +930,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FFIEC.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FFIEC.yaml
@@ -1057,6 +1057,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotsPublicProhibited:
     Properties:
       ConfigRuleName: rds-snapshots-public-prohibited

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
@@ -1085,6 +1085,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsResourcesProtectedByBackupPlan:
     Properties:
       ConfigRuleName: rds-resources-protected-by-backup-plan

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
@@ -748,6 +748,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsResourcesProtectedByBackupPlan:
     Properties:
       ConfigRuleName: rds-resources-protected-by-backup-plan

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
@@ -1038,6 +1038,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsResourcesProtectedByBackupPlan:
     Properties:
       ConfigRuleName: rds-resources-protected-by-backup-plan

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP.yaml
@@ -1081,6 +1081,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsResourcesProtectedByBackupPlan:
     Properties:
       ConfigRuleName: rds-resources-protected-by-backup-plan

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml
@@ -1004,6 +1004,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-KISMS.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-KISMS.yaml
@@ -991,6 +991,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-MAS-TRMG.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-MAS-TRMG.yaml
@@ -968,6 +968,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NBC-TRMG.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NBC-TRMG.yaml
@@ -1027,6 +1027,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CAF.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CAF.yaml
@@ -1007,6 +1007,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NCSC-CloudSec-Principles.yaml
@@ -1062,6 +1062,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-171.yaml
@@ -1040,6 +1040,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-4.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-4.yaml
@@ -845,6 +845,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-5.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-800-53-rev-5.yaml
@@ -998,6 +998,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-CSF.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-CSF.yaml
@@ -937,6 +937,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-Privacy-Framework.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NIST-Privacy-Framework.yaml
@@ -948,6 +948,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-NYDFS-23-NYCRR-500.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-NYDFS-23-NYCRR-500.yaml
@@ -971,6 +971,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotEncrypted:
     Properties:
       ConfigRuleName: rds-snapshot-encrypted

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-MasterDirection.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-RBI-MasterDirection.yaml
@@ -1054,6 +1054,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: RDS_MULTI_AZ_SUPPORT
     Type: AWS::Config::ConfigRule
+  RdsClusterMultiAzEnabled:
+    Properties:
+      ConfigRuleName: rds-cluster-multi-az-enabled
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBCluster
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_CLUSTER_MULTI_AZ_ENABLED
+    Type: AWS::Config::ConfigRule
   RdsSnapshotsPublicProhibited:
     Properties:
       ConfigRuleName: rds-snapshots-public-prohibited


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*

*Description of changes:* 
Updating the CPack templates to include RDS Multi-AZ cluster wherever Instance Multi-AZ Rule exists. This ensures that there is enough coverage of policy on RDS availability.
