### PR TITLE
Documentation expects a lowercase true

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart1.yaml
@@ -59,16 +59,16 @@ Parameters:
     Default: '24'
     Type: String
   IamPasswordPolicyParamRequireLowercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireNumbers:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireSymbols:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireUppercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
     Default: '90'

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-HighPart2.yaml
@@ -35,16 +35,16 @@ Parameters:
     Default: '24'
     Type: String
   IamPasswordPolicyParamRequireLowercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireNumbers:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireSymbols:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamPasswordPolicyParamRequireUppercaseCharacters:
-    Default: 'TRUE'
+    Default: 'true'
     Type: String
   IamUserUnusedCredentialsCheckParamMaxCredentialUsageAge:
     Default: '90'


### PR DESCRIPTION
I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)

*Issue #, if available:*
#434 

*Description of changes:*
Updating the values to be a lowercase `true` instead of `TRUE` which matches the expectation within the docs. https://docs.aws.amazon.com/config/latest/developerguide/iam-password-policy.html

After running a re-evaluation my password policy is within compliance