### PR TITLE
GovCloud Config rule fixes for FedRAMP Low Conformance Pack

### DIFF
--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
@@ -1,9 +1,9 @@
 ##################################################################################
 #
 #   Conformance Pack:
-#     Operational Best Practices for FedRAMP(Low)
+#     Operational Best Practices for FedRAMP (Low)
 #
-#   This conformance pack helps verify compliance with FedRAMP(Low) requirements.
+#   This conformance pack helps verify compliance with FedRAMP (Low) requirements.
 #
 #   This Conformance Pack has been designed for compatibility with the majority of AWS
 #   regions and to not require setting of any Parameters. Additional managed rules that

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
@@ -257,7 +257,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   CloudTrailEnabled:
     Properties:
-      ConfigRuleName: cloudtrail-enabled
+      ConfigRuleName: cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: CLOUD_TRAIL_ENABLED
@@ -476,7 +476,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   Ec2InstanceManagedBySsm:
     Properties:
-      ConfigRuleName: ec2-instance-managed-by-systems-manager
+      ConfigRuleName: ec2-instance-managed-by-ssm
       Scope:
         ComplianceResourceTypes:
         - AWS::EC2::Instance
@@ -558,16 +558,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: EC2_VOLUME_INUSE_CHECK
     Type: AWS::Config::ConfigRule
-  EcsTaskDefinitionMemoryHardLimit:
-    Properties:
-      ConfigRuleName: ecs-task-definition-memory-hard-limit
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::ECS::TaskDefinition
-      Source:
-        Owner: AWS
-        SourceIdentifier: ECS_TASK_DEFINITION_MEMORY_HARD_LIMIT
-    Type: AWS::Config::ConfigRule
+  # EcsTaskDefinitionMemoryHardLimit:
+  #   Properties:
+  #     ConfigRuleName: ecs-task-definition-memory-hard-limit
+  #     Scope:
+  #       ComplianceResourceTypes:
+  #       - AWS::ECS::TaskDefinition
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: ECS_TASK_DEFINITION_MEMORY_HARD_LIMIT
+  #   Type: AWS::Config::ConfigRule
   EcsTaskDefinitionUserForHostModeCheck:
     Properties:
       ConfigRuleName: ecs-task-definition-user-for-host-mode-check
@@ -869,7 +869,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   IncomingSshDisabled:
     Properties:
-      ConfigRuleName: restricted-ssh
+      ConfigRuleName: incoming-ssh-disabled
       Scope:
         ComplianceResourceTypes:
         - AWS::EC2::SecurityGroup
@@ -879,7 +879,7 @@ Resources:
     Type: AWS::Config::ConfigRule
   InstancesInVpc:
     Properties:
-      ConfigRuleName: ec2-instances-in-vpc
+      ConfigRuleName: instances-in-vpc
       Scope:
         ComplianceResourceTypes:
         - AWS::EC2::Instance
@@ -957,10 +957,17 @@ Resources:
     Type: AWS::Config::ConfigRule
   MultiRegionCloudTrailEnabled:
     Properties:
-      ConfigRuleName: multi-region-cloudtrail-enabled
+      ConfigRuleName: multi-region-cloud-trail-enabled
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED
+    Type: AWS::Config::ConfigRule
+  NaclNoUnrestrictedSshRdp:
+    Properties:
+      ConfigRuleName: nacl-no-unrestricted-ssh-rdp
+      Source:
+        Owner: AWS
+        SourceIdentifier: NACL_NO_UNRESTRICTED_SSH_RDP
     Type: AWS::Config::ConfigRule
   NoUnrestrictedRouteToIgw:
     Properties:
@@ -978,16 +985,16 @@ Resources:
         Owner: AWS
         SourceIdentifier: NO_UNRESTRICTED_ROUTE_TO_IGW
     Type: AWS::Config::ConfigRule
-  OpensearchInVpcOnly:
-    Properties:
-      ConfigRuleName: opensearch-in-vpc-only
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::OpenSearch::Domain
-      Source:
-        Owner: AWS
-        SourceIdentifier: OPENSEARCH_IN_VPC_ONLY
-    Type: AWS::Config::ConfigRule
+  # OpensearchInVpcOnly:
+  #   Properties:
+  #     ConfigRuleName: opensearch-in-vpc-only
+  #     Scope:
+  #       ComplianceResourceTypes:
+  #       - AWS::OpenSearch::Domain
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: OPENSEARCH_IN_VPC_ONLY
+  #   Type: AWS::Config::ConfigRule
   RdsEnhancedMonitoringEnabled:
     Properties:
       ConfigRuleName: rds-enhanced-monitoring-enabled
@@ -1122,56 +1129,56 @@ Resources:
         Owner: AWS
         SourceIdentifier: REDSHIFT_REQUIRE_TLS_SSL
     Type: AWS::Config::ConfigRule
-  RestrictedIncomingTraffic:
-    Properties:
-      ConfigRuleName: restricted-common-ports
-      InputParameters:
-        blockedPort1:
-          Fn::If:
-          - restrictedIncomingTrafficParamBlockedPort1
-          - Ref: RestrictedIncomingTrafficParamBlockedPort1
-          - Ref: AWS::NoValue
-        blockedPort2:
-          Fn::If:
-          - restrictedIncomingTrafficParamBlockedPort2
-          - Ref: RestrictedIncomingTrafficParamBlockedPort2
-          - Ref: AWS::NoValue
-        blockedPort3:
-          Fn::If:
-          - restrictedIncomingTrafficParamBlockedPort3
-          - Ref: RestrictedIncomingTrafficParamBlockedPort3
-          - Ref: AWS::NoValue
-        blockedPort4:
-          Fn::If:
-          - restrictedIncomingTrafficParamBlockedPort4
-          - Ref: RestrictedIncomingTrafficParamBlockedPort4
-          - Ref: AWS::NoValue
-        blockedPort5:
-          Fn::If:
-          - restrictedIncomingTrafficParamBlockedPort5
-          - Ref: RestrictedIncomingTrafficParamBlockedPort5
-          - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::EC2::SecurityGroup
-      Source:
-        Owner: AWS
-        SourceIdentifier: RESTRICTED_INCOMING_TRAFFIC
-    Type: AWS::Config::ConfigRule
-  RootAccountHardwareMfaEnabled:
-    Properties:
-      ConfigRuleName: root-account-hardware-mfa-enabled
-      Source:
-        Owner: AWS
-        SourceIdentifier: ROOT_ACCOUNT_HARDWARE_MFA_ENABLED
-    Type: AWS::Config::ConfigRule
-  RootAccountMfaEnabled:
-    Properties:
-      ConfigRuleName: root-account-mfa-enabled
-      Source:
-        Owner: AWS
-        SourceIdentifier: ROOT_ACCOUNT_MFA_ENABLED
-    Type: AWS::Config::ConfigRule
+  # RestrictedIncomingTraffic:
+  #   Properties:
+  #     ConfigRuleName: restricted-common-ports
+  #     InputParameters:
+  #       blockedPort1:
+  #         Fn::If:
+  #         - restrictedIncomingTrafficParamBlockedPort1
+  #         - Ref: RestrictedIncomingTrafficParamBlockedPort1
+  #         - Ref: AWS::NoValue
+  #       blockedPort2:
+  #         Fn::If:
+  #         - restrictedIncomingTrafficParamBlockedPort2
+  #         - Ref: RestrictedIncomingTrafficParamBlockedPort2
+  #         - Ref: AWS::NoValue
+  #       blockedPort3:
+  #         Fn::If:
+  #         - restrictedIncomingTrafficParamBlockedPort3
+  #         - Ref: RestrictedIncomingTrafficParamBlockedPort3
+  #         - Ref: AWS::NoValue
+  #       blockedPort4:
+  #         Fn::If:
+  #         - restrictedIncomingTrafficParamBlockedPort4
+  #         - Ref: RestrictedIncomingTrafficParamBlockedPort4
+  #         - Ref: AWS::NoValue
+  #       blockedPort5:
+  #         Fn::If:
+  #         - restrictedIncomingTrafficParamBlockedPort5
+  #         - Ref: RestrictedIncomingTrafficParamBlockedPort5
+  #         - Ref: AWS::NoValue
+  #     Scope:
+  #       ComplianceResourceTypes:
+  #       - AWS::EC2::SecurityGroup
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: RESTRICTED_INCOMING_TRAFFIC
+  #   Type: AWS::Config::ConfigRule
+  # RootAccountHardwareMfaEnabled:
+  #   Properties:
+  #     ConfigRuleName: root-account-hardware-mfa-enabled
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: ROOT_ACCOUNT_HARDWARE_MFA_ENABLED
+  #   Type: AWS::Config::ConfigRule
+  # RootAccountMfaEnabled:
+  #   Properties:
+  #     ConfigRuleName: root-account-mfa-enabled
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: ROOT_ACCOUNT_MFA_ENABLED
+  #   Type: AWS::Config::ConfigRule
   S3AccountLevelPublicAccessBlocksPeriodic:
     Properties:
       ConfigRuleName: s3-account-level-public-access-blocks-periodic

--- a/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
+++ b/aws-config-conformance-packs/Operational-Best-Practices-for-FedRAMP-Low.yaml
@@ -1364,15 +1364,15 @@ Resources:
         Owner: AWS
         SourceIdentifier: VPC_VPN_2_TUNNELS_UP
     Type: AWS::Config::ConfigRule
-  WafRegionalWebaclNotEmpty:
-    Properties:
-      ConfigRuleName: waf-regional-webacl-not-empty
-      Scope:
-        ComplianceResourceTypes:
-        - AWS::WAFRegional::WebACL
-      Source:
-        Owner: AWS
-        SourceIdentifier: WAF_REGIONAL_WEBACL_NOT_EMPTY
+  # WafRegionalWebaclNotEmpty:
+  #   Properties:
+  #     ConfigRuleName: waf-regional-webacl-not-empty
+  #     Scope:
+  #       ComplianceResourceTypes:
+  #       - AWS::WAFRegional::WebACL
+  #     Source:
+  #       Owner: AWS
+  #       SourceIdentifier: WAF_REGIONAL_WEBACL_NOT_EMPTY
     Type: AWS::Config::ConfigRule
   Wafv2LoggingEnabled:
     Properties:


### PR DESCRIPTION
*Issue #421 Conformance Pack for FedRamp not deployable in GovCloud*

*Description of changes:*
The FedRAMP Low conformance pack does not function in AWS Gov Cloud. Specifically the rules listed below are not in GovCloud or several other regions. I performed a full analysis of the non-GovCloud Config Rules and provided suggestions for how to update the rules. The full content of my analysis is available in this public spreadsheet: https://docs.google.com/spreadsheets/d/1eKZpe2EPA-8RQkG6bWViwLRrdDeS4yUpvtvUpu_4WEg/edit?usp=sharing

For an example see the documentation below on **root-account-mfa-enabled** https://docs.aws.amazon.com/config/latest/developerguide/root-account-mfa-enabled.html

> AWS Region: All supported AWS regions except China (Beijing), Asia Pacific (Thailand), Middle East (UAE), Asia Pacific (Malaysia), **AWS GovCloud (US-East)**, **AWS GovCloud (US-West)**, Mexico (Central), Israel (Tel Aviv), Canada West (Calgary), China (Ningxia) Region



<!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Config rules that need to be fixed | Suggested Change | Note
-- | -- | --
cloudtrail-enabled | cloud-trail-enabled | Add hypen (cloud-trail)
ec2-instance-managed-by-systems-manager | ec2-instance-managed-by-ssm | Acronym for SSM
ec2-instances-in-vpc | instances-in-vpc | Remove ec2
ecs-task-definition-memory-hard-limit | -- | Consider creating custom rule
multi-region-cloudtrail-enabled | multi-region-cloud-trail-enabled | Add hypen (cloud-trail)
opensearch-in-vpc-only | -- | elasticsearch-in-vpc-only already used
restricted-common-ports | nacl-no-unrestricted-ssh-rdp | Use similar rule
restricted-ssh | incoming-ssh-disabled | Use similar rule
root-account-hardware-mfa-enabled | -- | No root account MFA checks in GovCloud
root-account-mfa-enabled | -- | No root account MFA checks in GovCloud
waf-regional-webacl-not-empty | -- | Consider creating custom rule


These changes have been made in this pull request and I confirmed that this version of the conformance pack successfully deploys in AWS GovCloud. 


I confirm these files are made available under CC0 1.0 Universal (https://creativecommons.org/publicdomain/zero/1.0/legalcode)